### PR TITLE
docs: add instructions to spin up styleguide in browser

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,18 +5,24 @@
 
 From your friends at [Sparkbox](https://seesparkbox.com).
 
+## Spin Up the Sparkle Styleguide in a Browser
+1. From the root, run `npm run docs` to create the styleguide directory
+1. Navigate to the directory `cd styleguide`
+1. Run `python -m SimpleHTTPServer 3000` to spin up the project locally
+1. Navigate to localhost:3000 in your browser
+
 ## Creating a Sparkle Sub-System
 
 - Default Sass Map with at least three example values.
-- A function to access the map. 
-- A value added to the settings map to enable/disable the utility classes. 
+- A function to access the map.
+- A value added to the settings map to enable/disable the utility classes.
 - Utility classes that meet this criteria:
     - A check for if the utility class is enabled/disabled.
-    - Utility classes should be written to accept a namepspace. 
-    - Utility classes should be written to loop through all of the values in the map. 
-    - Loop includes media query prefixes for the class to be called at certain breakpoints. 
+    - Utility classes should be written to accept a namepspace.
+    - Utility classes should be written to loop through all of the values in the map.
+    - Loop includes media query prefixes for the class to be called at certain breakpoints.
 - Write test to check the function and class names.
-- Write documentation that can be configurable to the settings. 
+- Write documentation that can be configurable to the settings.
 
 
 ## Mixins
@@ -25,7 +31,7 @@ From your friends at [Sparkbox](https://seesparkbox.com).
 - Unbuttonize
 - Delist
 - Delink
-- Loop-mq 
+- Loop-mq
 - Antialiased
 - Clearfix
 
@@ -33,7 +39,7 @@ From your friends at [Sparkbox](https://seesparkbox.com).
 ## Funcitons
 
 - Map Getters (A system map retreiver)
-- SVG Encoder 
+- SVG Encoder
 - Strip-Unit
 - Negative
 - Ratio
@@ -42,7 +48,7 @@ From your friends at [Sparkbox](https://seesparkbox.com).
 - String Replace
 
 
-## Systems 
+## Systems
 
 - Spacing
     - Padding
@@ -53,7 +59,7 @@ From your friends at [Sparkbox](https://seesparkbox.com).
     - Background
     - Border
 - Grid
-- Font 
+- Font
     - Family
     - Size
     - Weight
@@ -70,7 +76,7 @@ From your friends at [Sparkbox](https://seesparkbox.com).
 - Text Alignment
 - Position
 - Font Style
-- Grid 
+- Grid
 
 
 

--- a/readme.md
+++ b/readme.md
@@ -36,16 +36,14 @@ From your friends at [Sparkbox](https://seesparkbox.com).
 - Clearfix
 
 
-## Funcitons
+## Functions
 
 - Map Getters (A system map retreiver)
-- SVG Encoder
 - Strip-Unit
 - Negative
 - Ratio
 - Stringify
 - Remify
-- String Replace
 
 
 ## Systems


### PR DESCRIPTION
## Description
Adds steps to see the styleguide in the browser. Addresses #26 

## To test
Check that the docs and their placement in the readme.md make sense.