### PR TITLE
feat: add css output examples to tools

### DIFF
--- a/mdcss/docs.scss
+++ b/mdcss/docs.scss
@@ -3,7 +3,7 @@ section: Introduction
 order: -1
 ---
 
-The Sparkle Utility Framework is a customizable system of Sass tools and classes that is intended to work within the Inverted Triangle CSS (ITCSS) organization method. This site is a resource of the settings, tools, and utility classes available for this website.
+The Sparkle Utility Framework is a customizable system of Sass tools and classes that is intended to work within the Inverted Triangle CSS (ITCSS) organization method. This site is a resource of the settings, tools, and utility classes available, including documentation about what each is, how to use them, and the CSS that they'll output.
 */
 
 /* ---

--- a/tools/antialiased/_mixin.scss
+++ b/tools/antialiased/_mixin.scss
@@ -4,9 +4,18 @@ section: Tools
 
 Adds font smoothing properties.
 
+**Use**
 ```scss
 .my-class {
   @include antialiased;
+}
+```
+
+**CSS Output**
+```css
+.my-class {
+  -moz-osx-font-smoothing: antialiased;
+  -webkit-font-smoothing: antialiased;
 }
 ```
 

--- a/tools/clearfix/_mixin.scss
+++ b/tools/clearfix/_mixin.scss
@@ -2,9 +2,19 @@
 title: Clearfix Mixin
 section: Tools
 
+**Use**
 ```scss
 .my-class {
   @include clearfix;
+}
+```
+
+**CSS Output**
+```css
+.my-class::after {
+  clear: both;
+  content: "";
+  display: table;
 }
 ```
 

--- a/tools/delink/_mixin.scss
+++ b/tools/delink/_mixin.scss
@@ -4,9 +4,18 @@ section: Tools
 
 Removes default link styles.
 
+**Use**
 ```scss
 .my-class {
   @include delink;
+}
+```
+
+**CSS Output**
+```css
+.my-class {
+  color: inherit;
+  text-decoration: none;
 }
 ```
 

--- a/tools/delist/_mixin.scss
+++ b/tools/delist/_mixin.scss
@@ -4,9 +4,19 @@ section: Tools
 
 Removes default list styles.
 
+**Use**
 ```scss
 .my-class {
   @include delist;
+}
+```
+
+**CSS Output**
+```css
+.my-class {
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 ```
 

--- a/tools/loop-mq/_mixin.scss
+++ b/tools/loop-mq/_mixin.scss
@@ -5,12 +5,50 @@ section: Tools
 
 Auto-generates media queries for looping content.
 
+**Use**
 ```scss
 .my-class {
   @include loop-mq {
     prop: value;
   }
 }
+```
+
+**Use with a prop**
+```scss
+.my-class {
+  @include loop-mq {
+    margin: 1rem;
+  }
+}
+```
+
+**CSS Output**
+```css
+.my-class {
+  margin: 1rem;
+}
+@media (min-width: 40rem) {
+  .my-class\@sm {
+    margin: 1rem;
+  }
+}
+@media (min-width: 60rem) {
+  .my-class\@md {
+    margin: 1rem;
+  }
+}
+@media (min-width: 80rem) {
+  .my-class\@lg {
+    margin: 1rem;
+  }
+}
+```
+
+**Note:** when using these classes in HTML, the `@` does not need to be escaped. Here's an example:
+
+```
+<p class="my-class@lg">No need to escape the @ symbol</p>
 ```
 
 */

--- a/tools/negative/_function.scss
+++ b/tools/negative/_function.scss
@@ -2,11 +2,26 @@
 title: Negative Function
 section: Tools
 
-Turns a positive number into a negative number.
+Turns a positive number into a negative number. This comes in handy when a variable is passed in, so `-$value` becomes explicit `negative($value)`.
 
+**Use**
 ```scss
 .test-class {
   prop: negative(<number>);
+}
+```
+
+**Use with a prop**
+```scss
+.test-class {
+  margin: negative(1rem);
+}
+```
+
+**CSS Output**
+```css
+.test-class {
+  margin: -1rem;
 }
 ```
 

--- a/tools/print-mq/_mixin.scss
+++ b/tools/print-mq/_mixin.scss
@@ -4,18 +4,48 @@ section: Tools
 
 Provides two functionalities. The first is to hide the element when printed.
 
+**Use**
 ```scss
 .my-class {
   @include print(hide);
 }
 ```
 
+**CSS Output**
+```css
+@media (print) {
+  .my-class {
+    display: none !important;
+  }
+}
+```
+
+
 The second functionality is to provide custom styles when printed.
 
+**Use**
 ```scss
 .my-class {
   @include print {
     prop: value;
+  }
+}
+```
+
+**Use with a prop**
+```scss
+.my-class {
+  @include print {
+    background-color: black;
+  }
+}
+```
+
+**CSS Output**
+```css
+@media print {
+  .my-class {
+    background-color: black;
   }
 }
 ```

--- a/tools/ratio/_function.scss
+++ b/tools/ratio/_function.scss
@@ -4,9 +4,24 @@ section: Tools
 
 Creates a ratio percentage value when given a height value and width value.
 
+**Use**
 ```scss
 .my-class {
   prop: ratio(<height>, <width>);
+}
+```
+
+**Use with a prop**
+```scss
+.my-class {
+  width: ratio(200, 400);
+}
+```
+
+**CSS Output**
+```css
+.my-class {
+  width: 50%;
 }
 ```
 

--- a/tools/remify/_function.scss
+++ b/tools/remify/_function.scss
@@ -4,9 +4,24 @@ section: Tools
 
 Converts a number to a rem value.
 
+**Use**
 ```scss
 .my-class {
   prop: remify(<number>);
+}
+```
+
+**Use with a prop**
+```scss
+.my-class {
+  margin: remify(24);
+}
+```
+
+**CSS Output**
+```css
+.my-class {
+  margin: 1.5rem;
 }
 ```
 

--- a/tools/stringify/_function.scss
+++ b/tools/stringify/_function.scss
@@ -4,9 +4,24 @@ section: Tools
 
 Converts a number to a string.
 
+**Use**
 ```scss
 .my-class {
   prop: stringify(<number>);
+}
+```
+
+**Use with a prop**
+```scss
+.my-class::before {
+  content: stringify(6);
+}
+```
+
+**CSS Output**
+```css
+.my-class::before {
+  content: '6';
 }
 ```
 

--- a/tools/strip-units/_function.scss
+++ b/tools/strip-units/_function.scss
@@ -2,14 +2,14 @@
 title: Strip Units Function
 section: Tools
 
-Removes the unit of number.
+Removes the unit of number. This is handy for maths in mixins/functions, for example if you need to check to values of two numbers. If one is a `em` value and the other is a `rem` value, you have to strip the units to accomplish the math.
 
+**Use**
 ```scss
 .my-class {
   prop: strip-units(<number>);
 }
 ```
-
 */
 
 @function strip-units($number) {

--- a/tools/unbuttonize/_mixin.scss
+++ b/tools/unbuttonize/_mixin.scss
@@ -4,16 +4,31 @@ section: Tools
 
 Removes styles added by default to button elements. For when something should semantically be a button, but isn't buttony in appearance.
 
+**Use**
 ```scss
 .my-class {
   @include unbuttonize;
 }
 ```
 
+**CSS Output**
+```css
+.my-class {
+  background-color: transparent;
+  color: inherit;
+  border: none;
+  margin: 0;
+  padding: 0;
+  text-align: inherit;
+  font: inherit;
+  border-radius: 0;
+  appearance: none;
+}
+```
+
 */
 
 @mixin unbuttonize {
-
   background-color: transparent;
   color: inherit;
   border: none;

--- a/tools/visually-hidden/_mixin.scss
+++ b/tools/visually-hidden/_mixin.scss
@@ -4,9 +4,18 @@ section: Tools
 
 Hides an element visually, but still accessible to screen readers.
 
+**Use**
 ```scss
 .my-class {
   @include visually-hidden;
+}
+```
+
+**CSS Output**
+```css
+.my-class {
+  position: fixed;
+  clip: rect(0, 0, 0, 0);
 }
 ```
 


### PR DESCRIPTION
## Description
Adds CSS output examples to all the tools. Addresses #28 

## To test
1. Spin up the styleguide
    1. From root `npm run docs`
    1. `cd styleguide`
    1. `python -m SimpleHTTPServer 3000`
    1. Navigate to localhost:3000
1. Look at the tools section
    1. Each one should have a CSS output example
    1. Do the examples make sense?
    1. Is the hierarchy easy to understand? Should the `Use` and `CSS Output` be bold like they are, or should they be headings?
1. Test any that you are unsure about against https://www.sassmeister.com/ (I did this before opening the PR, but always good to double check)