### PR TITLE
fix: text formatting to be consistent in styleguide

### DIFF
--- a/mdcss/_mdcss.scss
+++ b/mdcss/_mdcss.scss
@@ -1,4 +1,5 @@
 $hue: 330;
+$mdcss-text: #555;
 
 main > section + section {
   margin-top: 4rem;
@@ -6,6 +7,13 @@ main > section + section {
 
 .markdown-body {
   font-family: system-ui, sans-serif;
+
+  p {
+    margin-bottom: 1.875rem;
+    font-size: 1.25rem;
+    font-weight: 300;
+    color: $mdcss-text;
+  }
 }
 
 .container {


### PR DESCRIPTION
## Description
For some reason, mdcss was only applying styling to the first paragraph tag in a `.markdown-body`, so the text styling was inconsistent within one section of documentation. This PR fixes that by adding styling to all paragraph tags within `.markdown-body`. Address #29 

## To test
1. Spin up the styleguide
    1. From root `npm run docs`
    1. `cd styleguide`
    1. `python -m SimpleHTTPServer 3000`
    1. Navigate to localhost:3000
1. Go to the Print Mixin
1. Confirm that the sentence after the first code block (the one that starts "The second functionality") looks the same as the first sentence (the one that starts "The print mixin")