### PR TITLE
docs: Fix minor spelling errors

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ From your friends at [Sparkbox](https://seesparkbox.com).
 
 ## Functions
 
-- Map Getters (A system map retreiver)
+- Map Getters (A system map retriever)
 - Strip-Unit
 - Negative
 - Ratio
@@ -51,7 +51,7 @@ From your friends at [Sparkbox](https://seesparkbox.com).
 - Spacing
     - Padding
     - Margin
-    - Postion
+    - Position
 - Color
     - Foreground
     - Background


### PR DESCRIPTION
### What was done:
- Rearranged some letters

### What to verify
- The rearranging of letters equal out to English words ʕ •ᴥ•ʔ