### PR TITLE
Change background color for naming consistency

### DIFF
--- a/systems/color/background/_utility.scss
+++ b/systems/color/background/_utility.scss
@@ -23,16 +23,16 @@ section: Systems
 
 <tr>
 <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-<td>`.#{settings(prefix)}-bgcolor-#{$key}`</td>
-<td>`.#{settings(prefix)}-bgcolor-#{$key}:hover`</td>
-<td>`.#{settings(prefix)}-bgcolor-#{$key}:focus`</td>
-<td>`.#{settings(prefix)}-bgcolor-#{$key}:active`</td>
+<td>`.#{settings(prefix)}-background-color-#{$key}`</td>
+<td>`.#{settings(prefix)}-background-color-#{$key}:hover`</td>
+<td>`.#{settings(prefix)}-background-color-#{$key}:focus`</td>
+<td>`.#{settings(prefix)}-background-color-#{$key}:active`</td>
 </tr>
 */
-    .#{settings(prefix)}-bgcolor-#{$key},
-    .#{settings(prefix)}-bgcolor-#{$key}\:hover:hover,
-    .#{settings(prefix)}-bgcolor-#{$key}\:active:active,
-    .#{settings(prefix)}-bgcolor-#{$key}\:focus:focus {
+    .#{settings(prefix)}-background-color-#{$key},
+    .#{settings(prefix)}-background-color-#{$key}\:hover:hover,
+    .#{settings(prefix)}-background-color-#{$key}\:active:active,
+    .#{settings(prefix)}-background-color-#{$key}\:focus:focus {
       @include loop-mq {
         background-color: $val;
       }


### PR DESCRIPTION
### What was done:
- For background-color utility, changed `bgcolor` to `background-color`

### Why?
`bgcolor` is inconsistent with the other named color utility classes. So given: 
- `sparkle-border-color-<color-name>`
- `sparkle-decoration-color-<color-name>`

`sparkle-border-color-<color-name>` is more consistent.

Feel free to push back, as this is largely opinion-based.