### PR TITLE
feat: Text Decoration utility class

### DIFF
--- a/_sparkle-defaults.scss
+++ b/_sparkle-defaults.scss
@@ -22,4 +22,5 @@
 @import "utilities/display/map";
 @import "utilities/position/map";
 @import "utilities/text-align/map";
+@import "utilities/text-decoration/map";
 @import "utilities/text-transform/map";

--- a/_sparkle-settings.scss
+++ b/_sparkle-settings.scss
@@ -23,6 +23,7 @@ $settings: (
   'utility-display': true,
   'utility-position': true,
   'utility-text-align': true,
+  'utility-text-decoration': true,
   'utility-text-transform': true,
   'utility-visually-hidden': true
 ) !default;

--- a/_utilities.scss
+++ b/_utilities.scss
@@ -2,5 +2,6 @@
 @import "utilities/display/utility";
 @import "utilities/position/utility";
 @import "utilities/text-align/utility";
+@import "utilities/text-decoration/utility";
 @import "utilities/text-transform/utility";
 @import "utilities/visually-hidden/utility";

--- a/test/test.scss
+++ b/test/test.scss
@@ -42,6 +42,7 @@
 @import "../utilities/display/test";
 @import "../utilities/position/test";
 @import "../utilities/text-align/test";
+@import "../utilities/text-decoration/test";
 @import "../utilities/visually-hidden/test";
 
 // Globals

--- a/utilities/text-decoration/_map.scss
+++ b/utilities/text-decoration/_map.scss
@@ -1,0 +1,6 @@
+$util-text-decoration: (
+  none,
+  overline,
+  underline,
+  line-through
+) !default;

--- a/utilities/text-decoration/_mixin.scss
+++ b/utilities/text-decoration/_mixin.scss
@@ -1,0 +1,9 @@
+@mixin sparkle-text-decoration {
+  @each $value in $util-text-decoration {
+    .#{settings(prefix)}-text-decoration-#{$value} {
+      @include loop-mq {
+        text-decoration: $value;
+      }
+    }
+  }
+}

--- a/utilities/text-decoration/_test.scss
+++ b/utilities/text-decoration/_test.scss
@@ -8,39 +8,39 @@ $settings: (
   'loop-mq': true
 );
 
-$util-text-values: (
-  uppercase,
-  lowercase
+$util-text-decoration: (
+  none,
+  underline
 );
 
 $media-queries: (
   'sm': 40rem
 );
 
-@include describe('The position utility mixin') {
+@include describe('The text decoration utility mixin') {
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-text-transform();
+        @include sparkle-text-decoration();
       }
       @include expect {
-        .util-text-uppercase {
-          text-transform: uppercase;
+        .util-text-decoration-none {
+          text-decoration: none;
         }
 
         @media (min-width: 40rem) {
-          .util-text-uppercase\@sm {
-            text-transform: uppercase;
+          .util-text-decoration-none\@sm {
+            text-decoration: none;
           }
         }
 
-        .util-text-lowercase {
-          text-transform: lowercase;
+        .util-text-decoration-underline {
+          text-decoration: underline;
         }
 
         @media (min-width: 40rem) {
-          .util-text-lowercase\@sm {
-            text-transform: lowercase;
+          .util-text-decoration-underline\@sm {
+            text-decoration: underline;
           }
         }
       }

--- a/utilities/text-decoration/_utility.scss
+++ b/utilities/text-decoration/_utility.scss
@@ -1,0 +1,41 @@
+@import "mixin";
+
+@if settings(utility-text-decoration) {
+  /* ---
+title: Text Decoration Utility
+section: Utilities
+---
+
+<table>
+<thead>
+<tr>
+<th>Class Name</th>
+<th>Property</th>
+</thead>
+<tbody>
+*/
+
+  // NOTE: This @each loop is only for document generation
+  @each $value in $util-text-decoration {
+    /* ---
+section: Utilities
+---
+
+<tr>
+<td>`.#{settings(prefix)}-text-decoration-#{$value}`</td>
+<td>`text-decoration: #{$value}`</td>
+</tr>
+
+*/
+  }
+
+  /* ---
+section: Utilities
+---
+</tbody>
+</table>
+*/
+
+  // Load the mixin
+  @include sparkle-text-decoration;
+}


### PR DESCRIPTION
This adds a new utility class feature to Sparkle for the `text-decoration` property. This will allow for a class to apply or remove an underline, line-through, or overline.

1. Pull down branch.
1. Run `npm run docs`
1. Open `./styleguide/index.html` in your browser to find and view docs
1. Run `npm test` to verify tests pass
