### PR TITLE
fix: convert keys to strings for easer writing

### DIFF
--- a/systems/border/style/_function.scss
+++ b/systems/border/style/_function.scss
@@ -1,4 +1,4 @@
 @function border-style($key) {
-    @return map-get($border-style, $key);
+    @return map-get($border-style, stringify($key));
   }
   

--- a/systems/border/width/_function.scss
+++ b/systems/border/width/_function.scss
@@ -1,4 +1,4 @@
 @function border-width($key) {
-    @return map-get($border-width, $key);
+    @return map-get($border-width, stringify($key));
   }
   

--- a/systems/color/_function.scss
+++ b/systems/color/_function.scss
@@ -1,3 +1,3 @@
 @function color($key) {
-  @return map-get($colors, $key);
+  @return map-get($colors, stringify($key));
 }


### PR DESCRIPTION
This is a quality of life PR. This makes every function so they can be written as either `color(white)` or `color('white')`.