### PR TITLE
fix: Mistyped property name

### DIFF
--- a/systems/grid/gap/_mixin.scss
+++ b/systems/grid/gap/_mixin.scss
@@ -27,6 +27,7 @@
     .#{settings(prefix)}-gap-#{$key} {
       @include loop-mq {
         grid-gap: $value;
+        gap: $value;
       }
     }
   }
@@ -48,7 +49,8 @@
     */
     .#{settings(prefix)}-gap-row-#{$key} {
       @include loop-mq {
-        grid-gap-rows: $value;
+        grid-row-gap: $value;
+        row-gap: $value;
       }
     }
   }
@@ -70,7 +72,8 @@
     */
     .#{settings(prefix)}-gap-column-#{$key} {
       @include loop-mq {
-        grid-gap-columns: $value;
+        grid-column-gap: $value;
+        column-gap: $value;
       }
     }
   }


### PR DESCRIPTION
The property names for Gap Row and Column were mistyped. This fixes those.

Also, this adds the non `grid-` prefixed version in accordance with updates to the gap properties.