### PR TITLE
feat: Set minimum Node version at 12.0.0 and NPM version to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/sparkbox/sparkle#readme",
   "engines": {
-    "node": "^12.18.0",
-    "npm": "^6.14.8"
+    "node": "^12.0.0",
+    "npm": "^6.0.0"
   },
   "dependencies": {
     "mocha": "^8.1.3"


### PR DESCRIPTION
I don't think we need to be so specific, this will relax the requirements on build systems.