### PR TITLE
feat: Add flexbox utility classes

### DIFF
--- a/_sparkle-defaults.scss
+++ b/_sparkle-defaults.scss
@@ -24,3 +24,9 @@
 @import "utilities/text-align/map";
 @import "utilities/text-decoration/map";
 @import "utilities/text-transform/map";
+@import "utilities/justify-content/map";
+@import "utilities/align-items/map";
+@import "utilities/align-self/map";
+@import "utilities/order/map";
+@import "utilities/flex-direction/map";
+@import "utilities/flex-wrap/map";

--- a/_sparkle-settings.scss
+++ b/_sparkle-settings.scss
@@ -25,5 +25,13 @@ $settings: (
   'utility-text-align': true,
   'utility-text-decoration': true,
   'utility-text-transform': true,
-  'utility-visually-hidden': true
+  'utility-visually-hidden': true,
+  'utility-justify-content': true,
+  'utility-align-items': true,
+  'utility-align-self': true,
+  'utility-order': true,
+  'utility-flex-direction': true,
+  'utility-flex-grow': true,
+  'utility-flex-shrink': true,
+  'utility-flex-wrap': true
 ) !default;

--- a/_utilities.scss
+++ b/_utilities.scss
@@ -5,3 +5,12 @@
 @import "utilities/text-decoration/utility";
 @import "utilities/text-transform/utility";
 @import "utilities/visually-hidden/utility";
+@import "utilities/justify-content/utility";
+@import "utilities/align-items/utility";
+@import "utilities/align-self/utility";
+@import "utilities/order/utility";
+@import "utilities/flex-direction/utility";
+@import "utilities/flex-grow/utility";
+@import "utilities/flex-shrink/utility";
+@import "utilities/flex-wrap/utility";
+

--- a/test/test.scss
+++ b/test/test.scss
@@ -44,6 +44,14 @@
 @import "../utilities/text-align/test";
 @import "../utilities/text-decoration/test";
 @import "../utilities/visually-hidden/test";
+@import "../utilities/justify-content/test";
+@import "../utilities/align-items/test";
+@import "../utilities/align-self/test";
+@import "../utilities/order/test";
+@import "../utilities/flex-direction/test";
+@import "../utilities/flex-grow/test";
+@import "../utilities/flex-shrink/test";
+@import "../utilities/flex-wrap/test";
 
 // Globals
 @import "../globals/media-queries/test";

--- a/utilities/align-items/_map.scss
+++ b/utilities/align-items/_map.scss
@@ -1,0 +1,8 @@
+$util-align-items-values: (
+  start,
+  end,
+  flex-start,
+  flex-end,
+  center,
+  stretch
+) !default;

--- a/utilities/align-items/_mixin.scss
+++ b/utilities/align-items/_mixin.scss
@@ -1,0 +1,9 @@
+@mixin sparkle-align-items {
+  @each $value in $util-align-items-values {
+    .#{settings(prefix)}-align-items-#{$value} {
+      @include loop-mq {
+        align-items: $value;
+      }
+    }
+  }
+}

--- a/utilities/align-items/_test.scss
+++ b/utilities/align-items/_test.scss
@@ -1,0 +1,49 @@
+@import 'true';
+@import 'mixin';
+@import '../../tools/settings/function';
+@import '../../tools/loop-mq/mixin';
+
+$settings: (
+  'prefix': 'util',
+  'loop-mq': true
+);
+
+$util-align-items-values: (
+  center,
+  stretch
+);
+
+$media-queries: (
+  'sm': 40rem
+);
+
+@include describe('The align-items utility mixin') {
+  @include it('outputs the proper utility classes') {
+    @include assert {
+      @include output {
+        @include sparkle-align-items();
+      }
+      @include expect {
+        .util-align-items-center {
+          align-items: center;
+        }
+
+        @media (min-width: 40rem) {
+          .util-align-items-center\@sm {
+            align-items: center;
+          }
+        }
+
+        .util-align-items-stretch {
+          align-items: stretch;
+        }
+
+        @media (min-width: 40rem) {
+          .util-align-items-stretch\@sm {
+            align-items: stretch;
+          }
+        }
+      }
+    }
+  }
+}

--- a/utilities/align-items/_utility.scss
+++ b/utilities/align-items/_utility.scss
@@ -1,0 +1,38 @@
+@import "mixin";
+
+@if settings(utility-align-items) {
+  /* ---
+  title: Align Items Utility
+  section: Utilities
+  ---
+  <table>
+  <thead>
+  <tr>
+  <th>Class Name</th>
+  <th>Property</th>
+  </thead>
+  <tbody>
+  */
+
+  // NOTE: This @each loop is only for document generation
+  @each $value in $util-align-items-values {
+    /* ---
+    section: Utilities
+    ---
+    <tr>
+    <td>`.#{settings(prefix)}-align-items-#{$value}`</td>
+    <td>`align-items: #{$value}`</td>
+    </tr>
+    */
+  }
+
+  /* ---
+  section: Utilities
+  ---
+  </tbody>
+  </table>
+  */
+
+  // Load the mixin
+  @include sparkle-align-items;
+}

--- a/utilities/align-self/_map.scss
+++ b/utilities/align-self/_map.scss
@@ -1,0 +1,8 @@
+$util-align-self-values: (
+  start,
+  end,
+  flex-start,
+  flex-end,
+  center,
+  stretch
+) !default;

--- a/utilities/align-self/_mixin.scss
+++ b/utilities/align-self/_mixin.scss
@@ -1,0 +1,9 @@
+@mixin sparkle-align-self {
+  @each $value in $util-align-self-values {
+    .#{settings(prefix)}-align-self-#{$value} {
+      @include loop-mq {
+        align-self: $value;
+      }
+    }
+  }
+}

--- a/utilities/align-self/_test.scss
+++ b/utilities/align-self/_test.scss
@@ -1,0 +1,49 @@
+@import 'true';
+@import 'mixin';
+@import '../../tools/settings/function';
+@import '../../tools/loop-mq/mixin';
+
+$settings: (
+  'prefix': 'util',
+  'loop-mq': true
+);
+
+$util-align-self-values: (
+  center,
+  stretch
+);
+
+$media-queries: (
+  'sm': 40rem
+);
+
+@include describe('The align-self utility mixin') {
+  @include it('outputs the proper utility classes') {
+    @include assert {
+      @include output {
+        @include sparkle-align-self();
+      }
+      @include expect {
+        .util-align-self-center {
+          align-self: center;
+        }
+
+        @media (min-width: 40rem) {
+          .util-align-self-center\@sm {
+            align-self: center;
+          }
+        }
+
+        .util-align-self-stretch {
+          align-self: stretch;
+        }
+
+        @media (min-width: 40rem) {
+          .util-align-self-stretch\@sm {
+            align-self: stretch;
+          }
+        }
+      }
+    }
+  }
+}

--- a/utilities/align-self/_utility.scss
+++ b/utilities/align-self/_utility.scss
@@ -1,0 +1,38 @@
+@import "mixin";
+
+@if settings(utility-align-self) {
+  /* ---
+  title: Align Self Utility
+  section: Utilities
+  ---
+  <table>
+  <thead>
+  <tr>
+  <th>Class Name</th>
+  <th>Property</th>
+  </thead>
+  <tbody>
+  */
+
+  // NOTE: This @each loop is only for document generation
+  @each $value in $util-align-self-values {
+    /* ---
+    section: Utilities
+    ---
+    <tr>
+    <td>`.#{settings(prefix)}-align-self-#{$value}`</td>
+    <td>`align-self: #{$value}`</td>
+    </tr>
+    */
+  }
+
+  /* ---
+  section: Utilities
+  ---
+  </tbody>
+  </table>
+  */
+
+  // Load the mixin
+  @include sparkle-align-self;
+}

--- a/utilities/flex-direction/_map.scss
+++ b/utilities/flex-direction/_map.scss
@@ -1,0 +1,6 @@
+$util-flex-direction-values: (
+  row,
+  row-reverse,
+  column,
+  column-reverse
+) !default;

--- a/utilities/flex-direction/_mixin.scss
+++ b/utilities/flex-direction/_mixin.scss
@@ -1,0 +1,9 @@
+@mixin sparkle-flex-direction {
+  @each $value in $util-flex-direction-values {
+    .#{settings(prefix)}-flex-#{$value} {
+      @include loop-mq {
+        flex-direction: $value;
+      }
+    }
+  }
+}

--- a/utilities/flex-direction/_test.scss
+++ b/utilities/flex-direction/_test.scss
@@ -1,0 +1,49 @@
+@import 'true';
+@import 'mixin';
+@import '../../tools/settings/function';
+@import '../../tools/loop-mq/mixin';
+
+$settings: (
+  'prefix': 'util',
+  'loop-mq': true
+);
+
+$util-flex-direction-values: (
+  row,
+  column
+);
+
+$media-queries: (
+  'sm': 40rem
+);
+
+@include describe('The flex-direction utility mixin') {
+  @include it('outputs the proper utility classes') {
+    @include assert {
+      @include output {
+        @include sparkle-flex-direction();
+      }
+      @include expect {
+        .util-flex-row {
+          flex-direction: row;
+        }
+
+        @media (min-width: 40rem) {
+          .util-flex-row\@sm {
+            flex-direction: row;
+          }
+        }
+
+        .util-flex-column {
+          flex-direction: column;
+        }
+
+        @media (min-width: 40rem) {
+          .util-flex-column\@sm {
+            flex-direction: column;
+          }
+        }
+      }
+    }
+  }
+}

--- a/utilities/flex-direction/_utility.scss
+++ b/utilities/flex-direction/_utility.scss
@@ -1,0 +1,38 @@
+@import "mixin";
+
+@if settings(utility-flex-direction) {
+  /* ---
+  title: Flex Direction Utility
+  section: Utilities
+  ---
+  <table>
+  <thead>
+  <tr>
+  <th>Class Name</th>
+  <th>Property</th>
+  </thead>
+  <tbody>
+  */
+
+  // NOTE: This @each loop is only for document generation
+  @each $value in $util-flex-direction-values {
+    /* ---
+    section: Utilities
+    ---
+    <tr>
+    <td>`.#{settings(prefix)}-flex-#{$value}`</td>
+    <td>`flex-direction: #{$value}`</td>
+    </tr>
+    */
+  }
+
+  /* ---
+  section: Utilities
+  ---
+  </tbody>
+  </table>
+  */
+
+  // Load the mixin
+  @include sparkle-flex-direction;
+}

--- a/utilities/flex-grow/_mixin.scss
+++ b/utilities/flex-grow/_mixin.scss
@@ -1,0 +1,9 @@
+@mixin sparkle-flex-grow {
+  @for $value from 0 through 2 {
+    .#{settings(prefix)}-flex-grow-#{$value} {
+      @include loop-mq {
+        flex-grow: $value;
+      }
+    }
+  }
+}

--- a/utilities/flex-grow/_test.scss
+++ b/utilities/flex-grow/_test.scss
@@ -1,0 +1,54 @@
+@import 'true';
+@import 'mixin';
+@import '../../tools/settings/function';
+@import '../../tools/loop-mq/mixin';
+
+$settings: (
+  'prefix': 'util',
+  'loop-mq': true
+);
+
+$media-queries: (
+  'sm': 40rem
+);
+
+@include describe('The flex-grow utility mixin') {
+  @include it('outputs the proper utility classes') {
+    @include assert {
+      @include output {
+        @include sparkle-flex-grow();
+      }
+      @include expect {
+        .util-flex-grow-0 {
+          flex-grow: 0;
+        }
+
+        @media (min-width: 40rem) {
+          .util-flex-grow-0\@sm {
+            flex-grow: 0;
+          }
+        }
+
+        .util-flex-grow-1 {
+          flex-grow: 1;
+        }
+
+        @media (min-width: 40rem) {
+          .util-flex-grow-1\@sm {
+            flex-grow: 1;
+          }
+        }
+
+        .util-flex-grow-2 {
+          flex-grow: 2;
+        }
+
+        @media (min-width: 40rem) {
+          .util-flex-grow-2\@sm {
+            flex-grow: 2;
+          }
+        }
+      }
+    }
+  }
+}

--- a/utilities/flex-grow/_utility.scss
+++ b/utilities/flex-grow/_utility.scss
@@ -1,0 +1,38 @@
+@import "mixin";
+
+@if settings(utility-flex-grow) {
+  /* ---
+  title: Flex Grow Utility
+  section: Utilities
+  ---
+  <table>
+  <thead>
+  <tr>
+  <th>Class Name</th>
+  <th>Property</th>
+  </thead>
+  <tbody>
+  */
+
+  // NOTE: This @for loop is only for document generation
+  @for $value from 0 through 2 {
+    /* ---
+    section: Utilities
+    ---
+    <tr>
+    <td>`.#{settings(prefix)}-flex-grow-#{$value}`</td>
+    <td>`flex-grow: #{$value}`</td>
+    </tr>
+    */
+  }
+
+  /* ---
+  section: Utilities
+  ---
+  </tbody>
+  </table>
+  */
+
+  // Load the mixin
+  @include sparkle-flex-grow;
+}

--- a/utilities/flex-shrink/_mixin.scss
+++ b/utilities/flex-shrink/_mixin.scss
@@ -1,0 +1,9 @@
+@mixin sparkle-flex-shrink {
+  @for $value from 0 through 2 {
+    .#{settings(prefix)}-flex-shrink-#{$value} {
+      @include loop-mq {
+        flex-shrink: $value;
+      }
+    }
+  }
+}

--- a/utilities/flex-shrink/_test.scss
+++ b/utilities/flex-shrink/_test.scss
@@ -1,0 +1,54 @@
+@import 'true';
+@import 'mixin';
+@import '../../tools/settings/function';
+@import '../../tools/loop-mq/mixin';
+
+$settings: (
+  'prefix': 'util',
+  'loop-mq': true
+);
+
+$media-queries: (
+  'sm': 40rem
+);
+
+@include describe('The flex-shrink utility mixin') {
+  @include it('outputs the proper utility classes') {
+    @include assert {
+      @include output {
+        @include sparkle-flex-shrink();
+      }
+      @include expect {
+        .util-flex-shrink-0 {
+          flex-shrink: 0;
+        }
+
+        @media (min-width: 40rem) {
+          .util-flex-shrink-0\@sm {
+            flex-shrink: 0;
+          }
+        }
+
+        .util-flex-shrink-1 {
+          flex-shrink: 1;
+        }
+
+        @media (min-width: 40rem) {
+          .util-flex-shrink-1\@sm {
+            flex-shrink: 1;
+          }
+        }
+
+        .util-flex-shrink-2 {
+          flex-shrink: 2;
+        }
+
+        @media (min-width: 40rem) {
+          .util-flex-shrink-2\@sm {
+            flex-shrink: 2;
+          }
+        }
+      }
+    }
+  }
+}

--- a/utilities/flex-shrink/_utility.scss
+++ b/utilities/flex-shrink/_utility.scss
@@ -1,0 +1,38 @@
+@import "mixin";
+
+@if settings(utility-flex-shrink) {
+  /* ---
+  title: Flex Shrink Utility
+  section: Utilities
+  ---
+  <table>
+  <thead>
+  <tr>
+  <th>Class Name</th>
+  <th>Property</th>
+  </thead>
+  <tbody>
+  */
+
+  // NOTE: This @for loop is only for document generation
+  @for $value from 0 through 2 {
+    /* ---
+    section: Utilities
+    ---
+    <tr>
+    <td>`.#{settings(prefix)}-flex-shrink-#{$value}`</td>
+    <td>`flex-shrink: #{$value}`</td>
+    </tr>
+    */
+  }
+
+  /* ---
+  section: Utilities
+  ---
+  </tbody>
+  </table>
+  */
+
+  // Load the mixin
+  @include sparkle-flex-shrink;
+}

--- a/utilities/flex-wrap/_map.scss
+++ b/utilities/flex-wrap/_map.scss
@@ -1,0 +1,5 @@
+$util-flex-wrap-values: (
+  wrap,
+  nowrap,
+  wrap-reverse
+) !default;

--- a/utilities/flex-wrap/_mixin.scss
+++ b/utilities/flex-wrap/_mixin.scss
@@ -1,0 +1,9 @@
+@mixin sparkle-flex-wrap {
+  @each $value in $util-flex-wrap-values {
+    .#{settings(prefix)}-flex-#{$value} {
+      @include loop-mq {
+        flex-wrap: $value;
+      }
+    }
+  }
+}

--- a/utilities/flex-wrap/_test.scss
+++ b/utilities/flex-wrap/_test.scss
@@ -1,0 +1,49 @@
+@import 'true';
+@import 'mixin';
+@import '../../tools/settings/function';
+@import '../../tools/loop-mq/mixin';
+
+$settings: (
+  'prefix': 'util',
+  'loop-mq': true
+);
+
+$util-flex-wrap-values: (
+  wrap,
+  nowrap
+);
+
+$media-queries: (
+  'sm': 40rem
+);
+
+@include describe('The flex-wrap utility mixin') {
+  @include it('outputs the proper utility classes') {
+    @include assert {
+      @include output {
+        @include sparkle-flex-wrap();
+      }
+      @include expect {
+        .util-flex-wrap {
+          flex-wrap: wrap;
+        }
+
+        @media (min-width: 40rem) {
+          .util-flex-wrap\@sm {
+            flex-wrap: wrap;
+          }
+        }
+
+        .util-flex-nowrap {
+          flex-wrap: nowrap;
+        }
+
+        @media (min-width: 40rem) {
+          .util-flex-nowrap\@sm {
+            flex-wrap: nowrap;
+          }
+        }
+      }
+    }
+  }
+}

--- a/utilities/flex-wrap/_utility.scss
+++ b/utilities/flex-wrap/_utility.scss
@@ -1,0 +1,38 @@
+@import "mixin";
+
+@if settings(utility-flex-wrap) {
+  /* ---
+  title: Flex Wrap Utility
+  section: Utilities
+  ---
+  <table>
+  <thead>
+  <tr>
+  <th>Class Name</th>
+  <th>Property</th>
+  </thead>
+  <tbody>
+  */
+
+  // NOTE: This @each loop is only for document generation
+  @each $value in $util-flex-wrap-values {
+    /* ---
+    section: Utilities
+    ---
+    <tr>
+    <td>`.#{settings(prefix)}-flex-#{$value}`</td>
+    <td>`flex-wrap: #{$value}`</td>
+    </tr>
+    */
+  }
+
+  /* ---
+  section: Utilities
+  ---
+  </tbody>
+  </table>
+  */
+
+  // Load the mixin
+  @include sparkle-flex-wrap;
+}

--- a/utilities/justify-content/_map.scss
+++ b/utilities/justify-content/_map.scss
@@ -1,0 +1,11 @@
+$util-justify-values: (
+  start,
+  end,
+  flex-start,
+  flex-end,
+  center,
+  space-between,
+  space-around,
+  space-evenly,
+  stretch
+) !default;

--- a/utilities/justify-content/_mixin.scss
+++ b/utilities/justify-content/_mixin.scss
@@ -1,0 +1,9 @@
+@mixin sparkle-justify-content {
+  @each $value in $util-justify-values {
+    .#{settings(prefix)}-justify-content-#{$value} {
+      @include loop-mq {
+        justify-content: $value;
+      }
+    }
+  }
+}

--- a/utilities/justify-content/_test.scss
+++ b/utilities/justify-content/_test.scss
@@ -1,0 +1,49 @@
+@import 'true';
+@import 'mixin';
+@import '../../tools/settings/function';
+@import '../../tools/loop-mq/mixin';
+
+$settings: (
+  'prefix': 'util',
+  'loop-mq': true
+);
+
+$util-justify-values: (
+  center,
+  stretch
+);
+
+$media-queries: (
+  'sm': 40rem
+);
+
+@include describe('The justify-content utility mixin') {
+  @include it('outputs the proper utility classes') {
+    @include assert {
+      @include output {
+        @include sparkle-justify-content();
+      }
+      @include expect {
+        .util-justify-content-center {
+          justify-content: center;
+        }
+
+        @media (min-width: 40rem) {
+          .util-justify-content-center\@sm {
+            justify-content: center;
+          }
+        }
+
+        .util-justify-content-stretch {
+          justify-content: stretch;
+        }
+
+        @media (min-width: 40rem) {
+          .util-justify-content-stretch\@sm {
+            justify-content: stretch;
+          }
+        }
+      }
+    }
+  }
+}

--- a/utilities/justify-content/_utility.scss
+++ b/utilities/justify-content/_utility.scss
@@ -1,0 +1,38 @@
+@import "mixin";
+
+@if settings(utility-justify-content) {
+  /* ---
+  title: Justify Content Utility
+  section: Utilities
+  ---
+  <table>
+  <thead>
+  <tr>
+  <th>Class Name</th>
+  <th>Property</th>
+  </thead>
+  <tbody>
+  */
+
+  // NOTE: This @each loop is only for document generation
+  @each $value in $util-text-values {
+    /* ---
+    section: Utilities
+    ---
+    <tr>
+    <td>`.#{settings(prefix)}-justify-content-#{$value}`</td>
+    <td>`justify-content: #{$value}`</td>
+    </tr>
+    */
+  }
+
+  /* ---
+  section: Utilities
+  ---
+  </tbody>
+  </table>
+  */
+
+  // Load the mixin
+  @include sparkle-justify-content;
+}

--- a/utilities/order/_map.scss
+++ b/utilities/order/_map.scss
@@ -1,0 +1,9 @@
+$util-order-values: (
+  -1,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5
+) !default;

--- a/utilities/order/_mixin.scss
+++ b/utilities/order/_mixin.scss
@@ -1,0 +1,15 @@
+@mixin sparkle-order {
+  @each $value in $util-order-values {
+    $suffix: '';
+    @if $value == -1 {
+      $suffix: 'minus-1';
+    } @else {
+      $suffix: stringify($value);
+    }
+    .#{settings(prefix)}-order-#{$suffix} {
+      @include loop-mq {
+        order: $value;
+      }
+    }
+  }
+}

--- a/utilities/order/_test.scss
+++ b/utilities/order/_test.scss
@@ -1,0 +1,49 @@
+@import 'true';
+@import 'mixin';
+@import '../../tools/settings/function';
+@import '../../tools/loop-mq/mixin';
+
+$settings: (
+  'prefix': 'util',
+  'loop-mq': true
+);
+
+$util-order-values: (
+  -1,
+  1
+);
+
+$media-queries: (
+  'sm': 40rem
+);
+
+@include describe('The order utility mixin') {
+  @include it('outputs the proper utility classes') {
+    @include assert {
+      @include output {
+        @include sparkle-order();
+      }
+      @include expect {
+        .util-order-minus-1 {
+          order: -1;
+        }
+
+        @media (min-width: 40rem) {
+          .util-order-minus-1\@sm {
+            order: -1;
+          }
+        }
+
+        .util-order-1 {
+          order: 1;
+        }
+
+        @media (min-width: 40rem) {
+          .util-order-1\@sm {
+            order: 1;
+          }
+        }
+      }
+    }
+  }
+}

--- a/utilities/order/_utility.scss
+++ b/utilities/order/_utility.scss
@@ -1,0 +1,38 @@
+@import "mixin";
+
+@if settings(utility-order) {
+  /* ---
+  title: Order Utility
+  section: Utilities
+  ---
+  <table>
+  <thead>
+  <tr>
+  <th>Class Name</th>
+  <th>Property</th>
+  </thead>
+  <tbody>
+  */
+
+  // NOTE: This @each loop is only for document generation
+  @each $value in $util-order-values {
+    /* ---
+    section: Utilities
+    ---
+    <tr>
+    <td>`.#{settings(prefix)}-order-#{$value}`</td>
+    <td>`order: #{$value}`</td>
+    </tr>
+    */
+  }
+
+  /* ---
+  section: Utilities
+  ---
+  </tbody>
+  </table>
+  */
+
+  // Load the mixin
+  @include sparkle-order;
+}


### PR DESCRIPTION
Adds new flexbox utility classes for:
- flex-direction
- flex-wrap
- flex-grow
- flex-shrink
- order
- justify-content
- align-items
- align-self

For the reviewer:
- [x] Run tests by running `npm test`
- [ ] Run `npm run docs` and open `styleguide/index.html` in your browser and review the class tables for the utilities listed above.