### PR TITLE
fix: Move tool utility classes with  other utility classes

### DIFF
--- a/_tools.scss
+++ b/_tools.scss
@@ -30,10 +30,3 @@
 @import "tools/print-mq/mixin";
 @import "tools/unbuttonize/mixin";
 @import "tools/visually-hidden/mixin";
-
-// Utilities
-@import "tools/antialiased/utility";
-@import "tools/clearfix/utility";
-@import "tools/delink/utility";
-@import "tools/delist/utility";
-@import "tools/unbuttonize/utility";

--- a/_utilities.scss
+++ b/_utilities.scss
@@ -1,6 +1,20 @@
 /* BEGIN: Sparkle Utility Classes */
 
-// Utilities
+// Tool Utilities
+// --------------
+// Tool utility classes have corresponding mixins
+// which output the results of the mixins directly
+// so they can be used as a class as well as a mixin.
+@import "tools/antialiased/utility";
+@import "tools/clearfix/utility";
+@import "tools/delink/utility";
+@import "tools/delist/utility";
+@import "tools/unbuttonize/utility";
+
+// Property Utilities
+// ------------------
+// Property utilities are classes the correspond directly
+// to a CSS property and value combination.
 @import "utilities/display/utility";
 @import "utilities/position/utility";
 @import "utilities/text-align/utility";

--- a/mdcss/docs.scss
+++ b/mdcss/docs.scss
@@ -35,6 +35,9 @@ $sparkle-show-docs: true;
 }
 
 @import "../tools";
+
+/* |=========== N O   C S S   A B O V E   T H I S   L I N E ===========| */
+
 @import "mdcss";
 
 @if $sparkle-show-docs {


### PR DESCRIPTION
I discovered that there was a small group of utility classes there were being pulled in with the tools section, disrupting the inverted triangle structure. This PR moves the utility classes to the bottom of the cascade, where they should be, and adds in a large visual comment in the demo CSS file to state no CSS should render above that comment.