### PR TITLE
fix: make the docs comments optional

### DIFF
--- a/_utilities.scss
+++ b/_utilities.scss
@@ -1,3 +1,5 @@
+/* BEGIN: Sparkle Utility Classes */
+
 // Utilities
 @import "utilities/display/utility";
 @import "utilities/position/utility";
@@ -14,3 +16,4 @@
 @import "utilities/flex-shrink/utility";
 @import "utilities/flex-wrap/utility";
 
+/* END: Sparkle Utility Classes */

--- a/globals/media-queries/_docs.scss
+++ b/globals/media-queries/_docs.scss
@@ -1,54 +1,56 @@
 @if settings(loop-mq) {
-  /* ---
-  title: Media Queries System
-  section: Systems
-  ---
+  @if $sparkle-show-docs {
+    /* ---
+    title: Media Queries System
+    section: Systems
+    ---
+    The media queries of this system are not intended to be the only media queries in your styles, but are meant to be the major media queries and inform the responsive suffixes that are applied to the utility classes.
 
-  The media queries of this system are not intended to be the only media queries in your styles, but are meant to be the major media queries and inform the responsive suffixes that are applied to the utility classes.
+    ### Media Queries Function
 
-  ### Media Queries Function
+    ```scss
+    @media (min-width: mq(<key>)) {
+      ...
+    }
+    ```
 
-  ```scss
-  @media (min-width: mq(<key>)) {
-    ...
-  }
-  ```
+    ### Responsive Suffix Classes
 
-  ### Responsive Suffix Classes
+    Responsive suffix classes scope a utility class’s styles to a media query. For example a class named `.display-block` add the property and value of `display: block`, it will have a companion class called `.display-block@md` that applies `display: block` only when the screen width is at the defined size for the `md` media query key.
 
-  Responsive suffix classes scope a utility class’s styles to a media query. For example a class named `.display-block` add the property and value of `display: block`, it will have a companion class called `.display-block@md` that applies `display: block` only when the screen width is at the defined size for the `md` media query key.
+    ### Framework Media Queries
 
-  ### Framework Media Queries
+    The following table contains a list of the media query values defined in this framework.
 
-  The following table contains a list of the media query values defined in this framework.
+    <table>
+    <title>Framework Media Queries</title>
+    <thead>
+    <tr>
+      <th>Function</th>
+      <th>Screen Width Size</th>
+      <th>Class Suffix</th>
+    </tr>
+    </thead>
+    <tbody>
+    */
 
-  <table>
-  <title>Framework Media Queries</title>
-  <thead>
-  <tr>
-    <th>Function</th>
-    <th>Screen Width Size</th>
-    <th>Class Suffix</th>
-  </tr>
-  </thead>
-  <tbody>
-  */
-  @each $key, $val in $media-queries {
+    @each $key, $val in $media-queries {
+      /* ---
+      section: Systems
+      ---
+      <tr>
+      <td>mq(#{$key})</td>
+      <td>#{$val}</td>
+      <td>@#{$key}</td>
+      </tr>
+      */
+    }
+
     /* ---
     section: Systems
     ---
-    <tr>
-    <td>mq(#{$key})</td>
-    <td>#{$val}</td>
-    <td>@#{$key}</td>
-    </tr>
+    </tbody>
+    </table>
     */
   }
-
-  /* ---
-  section: Systems
-  ---
-  </tbody>
-  </table>
-  */
 }

--- a/mdcss/docs.scss
+++ b/mdcss/docs.scss
@@ -1,44 +1,61 @@
-/* ---
-section: Introduction
-order: -1
----
+// This file generates the Sparkle Docs file
+// The variable below, `$sparkle-show-docs`
+// turns off and on the comments used to generate
+// the Docs. If this variable is set to false, the
+// docs will not generate.
+$sparkle-show-docs: true;
 
-The Sparkle Utility Framework is a customizable system of Sass tools and classes that is intended to work within the Inverted Triangle CSS (ITCSS) organization method. This site is a resource of the settings, tools, and utility classes available, including documentation about what each is, how to use them, and the CSS that they'll output.
-*/
+/* Begin Sparkle Docs */
 
-/* ---
-section: Settings
-order: -1
----
+@if $sparkle-show-docs {
+  /* ---
+  section: Introduction
+  order: -1
+  ---
+  The Sparkle Utility Framework is a customizable system of Sass tools and classes that is intended to work within the Inverted Triangle CSS (ITCSS) organization method. This site is a resource of the settings, tools, and utility classes available, including documentation about what each is, how to use them, and the CSS that they'll output.
+  */
 
-In the ITCSS method, settings are declared first and at the top of the Sass document. These contain all variables used throughout the tools and utilities. The settings inform what Tools, Systems, and Utilities are available in the framework. More details about settings setup can be found on the [Sparkle repo](https://github.com/sparkbox/sparkle).
-*/
+  /* ---
+  section: Settings
+  order: -1
+  ---
+  In the ITCSS method, settings are declared first and at the top of the Sass document. These contain all variables used throughout the tools and utilities. The settings inform what Tools, Systems, and Utilities are available in the framework. More details about settings setup can be found on the [Sparkle repo](https://github.com/sparkbox/sparkle).
+  */
+}
+
 @import "../settings";
 
-/* ---
-section: Tools
-order: -1
----
+@if $sparkle-show-docs {
+  /* ---
+  section: Tools
+  order: -1
+  ---
+  The second declaration of the ITCSS method are the tools. Tools are the Sass mixins and functions used throughout the framework.
+  */
+}
 
-The second declaration of the ITCSS method are the tools. Tools are the Sass mixins and functions used throughout the framework.
-*/
 @import "../tools";
 @import "mdcss";
 
-/* ---
-section: Systems
-order: -1
----
+@if $sparkle-show-docs {
+  /* ---
+  section: Systems
+  order: -1
+  ---
+  Systems are not on their own part of the ITCSS organization, but instead are a collection of Settings, Tools, and Utilities. Systems are the most complex and customizable part of this framework. Each System usually has at least a Sass Function and Sass Map, while some generate Utility classes as well.
+  */
+}
 
-Systems are not on their own part of the ITCSS organization, but instead are a collection of Settings, Tools, and Utilities. Systems are the most complex and customizable part of this framework. Each System usually has at least a Sass Function and Sass Map, while some generate Utility classes as well.
-*/
 @import "../globals/media-queries/docs";
 @import "../systems";
 
-/* ---
-section: Utilities
----
-
-The final declaration of the ITCSS method are the utilities. Any additional styles should be declared between Tools and Utilities. The utilities are classes that have distinct purposes. Some of the Utilities are part of a System. Systems contain specific mixins, functions, and utility classes around a specific aspect of the framework, for example the Color and Spacing systems.
-*/
+@if $sparkle-show-docs {
+  /* ---
+  section: Utilities
+  ---
+  The final declaration of the ITCSS method are the utilities. Any additional styles should be declared between Tools and Utilities. The utilities are classes that have distinct purposes. Some of the Utilities are part of a System. Systems contain specific mixins, functions, and utility classes around a specific aspect of the framework, for example the Color and Spacing systems.
+  */
+}
 @import "../utilities";
+
+/* End Sparkle Docs */

--- a/systems/border/position/_mixins.scss
+++ b/systems/border/position/_mixins.scss
@@ -11,16 +11,16 @@
     border-#{$side}: $space;
   }
 }
-  
-@mixin sparkle-border-spacing-side-loop($mq:null, $true-test:null) {
+
+@mixin sparkle-border-spacing-side-loop($mq:null) {
   @if $mq {
     $mq: '\\@' + $mq;
   }
 
   @each $side-key, $side-val in $sides {
     @each $border-key, $border-val in $border-width {
-      @if $true-test == null {
-        @if $mq == null {
+      @if $mq == null {
+        @if $sparkle-show-docs {
           /* ---
           section: Systems
           ---
@@ -40,8 +40,8 @@
   }
 }
 
-@mixin sparkle-border-spacing-loop($true-test:null) {
-  @if $true-test == null {
+@mixin sparkle-border-spacing-loop {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---
@@ -56,18 +56,18 @@
     <tbody>
     */
   }
-  @include sparkle-border-spacing-side-loop(null, $true-test);
+  @include sparkle-border-spacing-side-loop(null);
   @each $key, $val in $media-queries {
     @media (min-width: #{$val}) {
-      @include sparkle-border-spacing-side-loop($key, $true-test);
+      @include sparkle-border-spacing-side-loop($key);
     }
   }
   @if settings('print-classes') {
     @media print {
-      @include sparkle-border-spacing-side-loop(print, $true-test);
+      @include sparkle-border-spacing-side-loop(print);
     }
   }
-  @if $true-test == null {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---

--- a/systems/border/position/_test.scss
+++ b/systems/border/position/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixins';
 @import '../../../tools/loop-mq/mixin';
 
@@ -30,65 +32,65 @@ $sides: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-border-spacing-loop(true);
+        @include sparkle-border-spacing-loop;
       }
       @include expect {
         .util-border-btm-hairline {
           border-bottom: 1px;
         }
-        
+
         .util-border-top-hairline {
           border-top: 1px;
         }
-        
+
         .util-border-lft-hairline {
           border-left: 1px;
         }
-        
+
         .util-border-rgt-hairline {
           border-right: 1px;
         }
-        
+
         .util-border-all-hairline {
           border: 1px;
         }
-        
+
         .util-border-vrt-hairline {
           border-right: 1px;
           border-left: 1px;
         }
-        
+
         .util-border-hrz-hairline {
           border-top: 1px;
           border-bottom: 1px;
         }
-        
+
         @media (min-width: 40rem) {
           .util-border-btm-hairline\@sm {
             border-bottom: 1px;
           }
-        
+
           .util-border-top-hairline\@sm {
             border-top: 1px;
           }
-        
+
           .util-border-lft-hairline\@sm {
             border-left: 1px;
           }
-        
+
           .util-border-rgt-hairline\@sm {
             border-right: 1px;
           }
-        
+
           .util-border-all-hairline\@sm {
             border: 1px;
           }
-        
+
           .util-border-vrt-hairline\@sm {
             border-right: 1px;
             border-left: 1px;
           }
-        
+
           .util-border-hrz-hairline\@sm {
             border-top: 1px;
             border-bottom: 1px;

--- a/systems/border/position/_utility.scss
+++ b/systems/border/position/_utility.scss
@@ -1,13 +1,14 @@
 @import "mixins";
 
 @if settings(utility-border-position) {
+  @if $sparkle-show-docs {
     /* ---
     title: Border System
     section: Systems
     ---
 
-    ### Border Position and Width
-
+    ### Border Position and Width 
     */
+  }
   @include sparkle-border-spacing-loop();
 }

--- a/systems/border/style/_mixin.scss
+++ b/systems/border/style/_mixin.scss
@@ -1,5 +1,5 @@
-@mixin sparkle-border-style($true-test:null) {
-  @if $true-test == null {
+@mixin sparkle-border-style {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---
@@ -18,7 +18,7 @@
     */
   }
   @each $key, $value in $border-style {
-    @if $true-test == null {
+    @if $sparkle-show-docs {
       /* ---
       section: Systems
       ---
@@ -35,7 +35,7 @@
       }
     }
   }
-  @if $true-test == null {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---

--- a/systems/border/style/_test.scss
+++ b/systems/border/style/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../../tools/loop-mq/mixin';
 
@@ -19,13 +21,13 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-border-style(true);
+        @include sparkle-border-style;
       }
       @include expect {
         .util-border-style-solid {
           border-style: solid;
         }
-        
+
         @media (min-width: 40rem) {
           .util-border-style-solid\@sm {
             border-style: solid;

--- a/systems/border/width/_mixin.scss
+++ b/systems/border/width/_mixin.scss
@@ -1,5 +1,5 @@
-@mixin sparkle-border-width($true-test:null) {
-  @if $true-test == null {
+@mixin sparkle-border-width {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---
@@ -17,8 +17,9 @@
     <tbody>
     */
   }
+
   @each $key, $value in $border-width {
-    @if $true-test == null {
+    @if $sparkle-show-docs {
       /* ---
       section: Systems
       ---
@@ -35,7 +36,7 @@
       }
     }
   }
-  @if $true-test == null {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---

--- a/systems/border/width/_test.scss
+++ b/systems/border/width/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../../tools/loop-mq/mixin';
 
@@ -19,13 +21,13 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-border-width(true);
+        @include sparkle-border-width;
       }
       @include expect {
         .util-border-width-hairline {
           border-width: 1px;
         }
-        
+
         @media (min-width: 40rem) {
           .util-border-width-hairline\@sm {
             border-width: 1px;

--- a/systems/border/width/_utility.scss
+++ b/systems/border/width/_utility.scss
@@ -1,9 +1,11 @@
 @import "mixin";
 
 @if settings(utility-border-width) {
-  /* ---
-    section: Systems
-    ---
-    */
+  @if $sparkle-show-docs {
+    /* ---
+      section: Systems
+      ---
+      */
+  }
   @include sparkle-border-width();
 }

--- a/systems/color/_docs.scss
+++ b/systems/color/_docs.scss
@@ -1,40 +1,41 @@
 @if settings('system-color') {
-  /* ---
-title: Color System
-section: Systems
----
-
-<table>
-<thead>
-<tr>
-<th></th>
-<th>Color</th>
-<th>Name</th>
-<th>Function</th>
-</tr>
-</thead>
-<tbody>
-*/
-
-  @each $key, $val in $colors {
+  @if $sparkle-show-docs {
     /* ---
-section: Systems
----
+    title: Color System
+    section: Systems
+    ---
 
-<tr>
-<td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-<td>`#{$val}`</td>
-<td>#{$key}</td>
-<td>`color(#{$key})`</td>
-</tr>
-*/
+    <table>
+    <thead>
+    <tr>
+    <th></th>
+    <th>Color</th>
+    <th>Name</th>
+    <th>Function</th>
+    </tr>
+    </thead>
+    <tbody>
+    */
+
+    @each $key, $val in $colors {
+      /* ---
+        section: Systems
+        ---
+
+        <tr>
+        <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
+        <td>`#{$val}`</td>
+        <td>#{$key}</td>
+        <td>`color(#{$key})`</td>
+        </tr>
+        */
+    }
+
+    /* ---
+      section: Systems
+      ---
+      </tbody>
+      </table>
+      */
   }
-
-  /* ---
-section: Systems
----
-
-</tbody>
-</table>
-*/
 }

--- a/systems/color/background/_utility.scss
+++ b/systems/color/background/_utility.scss
@@ -1,36 +1,39 @@
 @if settings('utility-background-color') {
-/* ---
-section: Systems
----
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
 
-### Background Color Utility Classes
-
-<table>
-<thead>
-<tr>
-<th></th>
-<th>Default Class</th>
-<th>`:hover` Class</th>
-<th>`:focus` Class</th>
-<th>`:active` Class</th>
-</tr>
-</thead>
-<tbody>
-*/
+    ### Background Color Utility Classes
+    <table>
+    <thead>
+    <tr>
+    <th></th>
+    <th>Default Class</th>
+    <th>`:hover` Class</th>
+    <th>`:focus` Class</th>
+    <th>`:active` Class</th>
+    </tr>
+    </thead>
+    <tbody>
+    */
+  }
 
   @each $key, $val in $colors {
-/* ---
-section: Systems
----
+    @if $sparkle-show-docs {
+      /* ---
+      section: Systems
+      ---
+      <tr>
+      <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
+      <td>`.#{settings(prefix)}-background-color-#{$key}`</td>
+      <td>`.#{settings(prefix)}-background-color-#{$key}:hover`</td>
+      <td>`.#{settings(prefix)}-background-color-#{$key}:focus`</td>
+      <td>`.#{settings(prefix)}-background-color-#{$key}:active`</td>
+      </tr>
+      */
+    }
 
-<tr>
-<td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-<td>`.#{settings(prefix)}-background-color-#{$key}`</td>
-<td>`.#{settings(prefix)}-background-color-#{$key}:hover`</td>
-<td>`.#{settings(prefix)}-background-color-#{$key}:focus`</td>
-<td>`.#{settings(prefix)}-background-color-#{$key}:active`</td>
-</tr>
-*/
     .#{settings(prefix)}-background-color-#{$key},
     .#{settings(prefix)}-background-color-#{$key}\:hover:hover,
     .#{settings(prefix)}-background-color-#{$key}\:active:active,
@@ -41,11 +44,12 @@ section: Systems
     }
   }
 
-/* ---
-section: Systems
----
-
-</tbody>
-</table>
-*/
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    </tbody>
+    </table>
+    */
+  }
 }

--- a/systems/color/border/_utility.scss
+++ b/systems/color/border/_utility.scss
@@ -1,35 +1,37 @@
 @if settings('utility-border-color') {
-/* ---
-section: Systems
----
-### Border Color Utility Classes
-
-<table>
-<thead>
-<tr>
-<th></th>
-<th>Default Class</th>
-<th>`:hover` Class</th>
-<th>`:focus` Class</th>
-<th>`:active` Class</th>
-</tr>
-</thead>
-<tbody>
-*/
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    ### Border Color Utility Classes
+    <table>
+    <thead>
+    <tr>
+    <th></th>
+    <th>Default Class</th>
+    <th>`:hover` Class</th>
+    <th>`:focus` Class</th>
+    <th>`:active` Class</th>
+    </tr>
+    </thead>
+    <tbody>
+    */
+  }
 
   @each $key, $val in $colors {
-/* ---
-section: Systems
----
-
-<tr>
-<td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-<td>`.#{settings(prefix)}-border-color-#{$key}`</td>
-<td>`.#{settings(prefix)}-border-color-#{$key}:hover`</td>
-<td>`.#{settings(prefix)}-border-color-#{$key}:focus`</td>
-<td>`.#{settings(prefix)}-border-color-#{$key}:active`</td>
-</tr>
-*/
+    @if $sparkle-show-docs {
+      /* ---
+      section: Systems
+      ---
+      <tr>
+      <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
+      <td>`.#{settings(prefix)}-border-color-#{$key}`</td>
+      <td>`.#{settings(prefix)}-border-color-#{$key}:hover`</td>
+      <td>`.#{settings(prefix)}-border-color-#{$key}:focus`</td>
+      <td>`.#{settings(prefix)}-border-color-#{$key}:active`</td>
+      </tr>
+      */
+    }
     .#{settings(prefix)}-border-color-#{$key},
     .#{settings(prefix)}-border-color-#{$key}\:hover:hover,
     .#{settings(prefix)}-border-color-#{$key}\:active:active,
@@ -40,11 +42,12 @@ section: Systems
     }
   }
 
-/* ---
-section: Systems
----
-
-</tbody>
-</table>
-*/
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    </tbody>
+    </table>
+    */
+  }
 }

--- a/systems/color/foreground/_utility.scss
+++ b/systems/color/foreground/_utility.scss
@@ -1,35 +1,37 @@
 @if settings('utility-foreground-color') {
-/* ---
-section: Systems
----
-### Text Color Utility Classes
-
-<table>
-<thead>
-<tr>
-<th></th>
-<th>Default Class</th>
-<th>`:hover` Class</th>
-<th>`:focus` Class</th>
-<th>`:active` Class</th>
-</tr>
-</thead>
-<tbody>
-*/
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    ### Text Color Utility Classes
+    <table>
+    <thead>
+    <tr>
+    <th></th>
+    <th>Default Class</th>
+    <th>`:hover` Class</th>
+    <th>`:focus` Class</th>
+    <th>`:active` Class</th>
+    </tr>
+    </thead>
+    <tbody>
+    */
+  }
 
   @each $key, $val in $colors {
-/* ---
-section: Systems
----
-
-<tr>
-<td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-<td>`.#{settings(prefix)}-color-#{$key}`</td>
-<td>`.#{settings(prefix)}-color-#{$key}:hover`</td>
-<td>`.#{settings(prefix)}-color-#{$key}:focus`</td>
-<td>`.#{settings(prefix)}-color-#{$key}:active`</td>
-</tr>
-*/
+    @if $sparkle-show-docs {
+      /* ---
+      section: Systems
+      ---
+      <tr>
+      <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
+      <td>`.#{settings(prefix)}-color-#{$key}`</td>
+      <td>`.#{settings(prefix)}-color-#{$key}:hover`</td>
+      <td>`.#{settings(prefix)}-color-#{$key}:focus`</td>
+      <td>`.#{settings(prefix)}-color-#{$key}:active`</td>
+      </tr>
+      */
+    }
     .#{settings(prefix)}-color-#{$key},
     .#{settings(prefix)}-color-#{$key}\:hover:hover,
     .#{settings(prefix)}-color-#{$key}\:active:active,
@@ -40,11 +42,12 @@ section: Systems
     }
   }
 
-/* ---
-section: Systems
----
-
-</tbody>
-</table>
-*/
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    </tbody>
+    </table>
+    */
+  }
 }

--- a/systems/color/outline/_utility.scss
+++ b/systems/color/outline/_utility.scss
@@ -1,36 +1,38 @@
 @if settings('utility-outline-color') {
-/* ---
-section: Systems
----
-
-### Outline Color Utility Classes
-
-<table>
-<thead>
-<tr>
-<th></th>
-<th>Default Class</th>
-<th>`:hover` Class</th>
-<th>`:focus` Class</th>
-<th>`:active` Class</th>
-</tr>
-</thead>
-<tbody>
-*/
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    ### Outline Color Utility Classes
+    <table>
+    <thead>
+    <tr>
+    <th></th>
+    <th>Default Class</th>
+    <th>`:hover` Class</th>
+    <th>`:focus` Class</th>
+    <th>`:active` Class</th>
+    </tr>
+    </thead>
+    <tbody>
+    */
+  }
 
   @each $key, $val in $colors {
-/* ---
-section: Systems
----
+    @if $sparkle-show-docs {
+      /* ---
+      section: Systems
+      ---
+      <tr>
+      <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
+      <td>`.#{settings(prefix)}-outline-#{$key}`</td>
+      <td>`.#{settings(prefix)}-outline-#{$key}:hover`</td>
+      <td>`.#{settings(prefix)}-outline-#{$key}:focus`</td>
+      <td>`.#{settings(prefix)}-outline-#{$key}:active`</td>
+      </tr>
+      */
+    }
 
-<tr>
-<td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-<td>`.#{settings(prefix)}-outline-#{$key}`</td>
-<td>`.#{settings(prefix)}-outline-#{$key}:hover`</td>
-<td>`.#{settings(prefix)}-outline-#{$key}:focus`</td>
-<td>`.#{settings(prefix)}-outline-#{$key}:active`</td>
-</tr>
-*/
     .#{settings(prefix)}-outline-#{$key},
     .#{settings(prefix)}-outline-#{$key}\:hover:hover,
     .#{settings(prefix)}-outline-#{$key}\:active:active,
@@ -41,11 +43,12 @@ section: Systems
     }
   }
 
-/* ---
-section: Systems
----
-
-</tbody>
-</table>
-*/
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    </tbody>
+    </table>
+    */
+  }
 }

--- a/systems/color/text-decoration/_utility.scss
+++ b/systems/color/text-decoration/_utility.scss
@@ -1,36 +1,39 @@
 @if settings('utility-text-decoration-color') {
-/* ---
-section: Systems
----
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
 
-### Text Decoration Color Utility Classes
+    ### Text Decoration Color Utility Classes
 
-<table>
-<thead>
-<tr>
-<th></th>
-<th>Default Class</th>
-<th>`:hover` Class</th>
-<th>`:focus` Class</th>
-<th>`:active` Class</th>
-</tr>
-</thead>
-<tbody>
-*/
+    <table>
+    <thead>
+    <tr>
+    <th></th>
+    <th>Default Class</th>
+    <th>`:hover` Class</th>
+    <th>`:focus` Class</th>
+    <th>`:active` Class</th>
+    </tr>
+    </thead>
+    <tbody>
+    */
+  }
 
-    @each $key, $val in $colors {
-/* ---
-section: Systems
----
-
-<tr>
-<td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-<td>`.#{settings(prefix)}-decoration-color-#{$key}`</td>
-<td>`.#{settings(prefix)}-decoration-color-#{$key}:hover`</td>
-<td>`.#{settings(prefix)}-decoration-color-#{$key}:focus`</td>
-<td>`.#{settings(prefix)}-decoration-color-#{$key}:active`</td>
-</tr>
-*/
+  @each $key, $val in $colors {
+    @if $sparkle-show-docs {
+      /* ---
+      section: Systems
+      ---
+      <tr>
+      <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
+      <td>`.#{settings(prefix)}-decoration-color-#{$key}`</td>
+      <td>`.#{settings(prefix)}-decoration-color-#{$key}:hover`</td>
+      <td>`.#{settings(prefix)}-decoration-color-#{$key}:focus`</td>
+      <td>`.#{settings(prefix)}-decoration-color-#{$key}:active`</td>
+      </tr>
+      */
+    }
     .#{settings(prefix)}-decoration-color-#{$key},
     .#{settings(prefix)}-decoration-color-#{$key}\:hover:hover,
     .#{settings(prefix)}-decoration-color-#{$key}\:active:active,
@@ -41,11 +44,13 @@ section: Systems
     }
   }
 
-/* ---
-section: Systems
----
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
 
-</tbody>
-</table>
-*/
+    </tbody>
+    </table>
+    */
+  }
 }

--- a/systems/font/_docs.scss
+++ b/systems/font/_docs.scss
@@ -1,19 +1,21 @@
-/* ---
-title: Font System
-section: Systems
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Font System
+  section: Systems
+  ---
 
-Below are the font system functions and utilities.
+  Below are the font system functions and utilities.
 
-### Font Functions
+  ### Font Functions
 
-The font functions allow you to load the determined value by calling the function, e.g. `size()`, with the key from the corresponding map.
+  The font functions allow you to load the determined value by calling the function, e.g. `size()`, with the key from the corresponding map.
 
-```css
-.my-class {
-  font-family: family(<key>);
-  font-size: size(<key>);
-  font-weight: weight(<key>);
+  ```css
+  .my-class {
+    font-family: family(<key>);
+    font-size: size(<key>);
+    font-weight: weight(<key>);
+  }
+  ```
+  */
 }
-```
-*/

--- a/systems/font/family/_mixin.scss
+++ b/systems/font/family/_mixin.scss
@@ -1,5 +1,5 @@
-@mixin sparkle-font-family($true-test: null) {
-  @if $true-test == null {
+@mixin sparkle-font-family {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---
@@ -15,7 +15,7 @@
     */
   }
   @each $key, $value in $font-families {
-    @if $true-test == null {
+    @if $sparkle-show-docs {
       /* ---
       section: Systems
       ---
@@ -26,13 +26,14 @@
       </tr>
       */
     }
+
     .#{settings(prefix)}-family-#{$key} {
       @include loop-mq {
         font-family: $value;
       }
     }
   }
-  @if $true-test == null {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---

--- a/systems/font/family/_test.scss
+++ b/systems/font/family/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import "mixin";
 
 $font-families: (
@@ -12,24 +14,22 @@ $settings: (
   'system-font-family': true
 );
 
-$true-test: true;
-
 @include describe('The Font Families System') {
   @include it('outputs font-family classes.') {
     @include assert {
       @include output {
-        @include sparkle-font-family($true-test);
+        @include sparkle-font-family;
       }
-      
+
       @include expect {
         .true-test-family-sans {
             font-family: "Helvetica Nueue", Helvetica, sans-serif;
         }
-        
+
         .true-test-family-serif {
             font-family: Georgia, "Times New Roman", serif;
         }
-        
+
         .true-test-family-mono {
             font-family: Monaco, monospace;
         }

--- a/systems/font/size/_mixin.scss
+++ b/systems/font/size/_mixin.scss
@@ -1,5 +1,5 @@
-@mixin sparkle-font-size($true-test: null) {
-  @if $true-test == null {
+@mixin sparkle-font-size {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---
@@ -14,31 +14,31 @@
     <tbody>
     */
   }
-    @each $key, $value in $font-size {
-      @if $true-test == null {
-        /* ---
-        section: Systems
-        ---
-        <tr>
-        <td><code>#{settings(prefix)}-size-#{$key}</code></td>
-        <td><code>size(#{$key})</code></td>
-        <td><code>#{$key}: #{$value}</td>
-        </tr>
-        */
-      }
-      .#{settings(prefix)}-size-#{$key} {
-        @include loop-mq {
-          font-size: $value;
-        }
-      }
-    }
-    @if $true-test == null {
+
+  @each $key, $value in $font-size {
+    @if $sparkle-show-docs {
       /* ---
       section: Systems
       ---
-      </tbody>
-      </table>
+      <tr>
+      <td><code>#{settings(prefix)}-size-#{$key}</code></td>
+      <td><code>size(#{$key})</code></td>
+      <td><code>#{$key}: #{$value}</td>
+      </tr>
       */
     }
+    .#{settings(prefix)}-size-#{$key} {
+      @include loop-mq {
+        font-size: $value;
+      }
+    }
   }
-  
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    </tbody>
+    </table>
+    */
+  }
+}

--- a/systems/font/size/_test.scss
+++ b/systems/font/size/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import "mixin";
 
 $font-size: (
@@ -13,24 +15,22 @@ $settings: (
   'system-font-size': true
 );
 
-$true-test: true;
-
 @include describe('The Font Size System') {
   @include it('outputs font-size classes.') {
     @include assert {
       @include output {
-        @include sparkle-font-size($true-test);
+        @include sparkle-font-size;
       }
-      
+
       @include expect {
         .true-test-size-sm {
           font-size: 0.875rem;
         }
-          
+
         .true-test-size-md {
           font-size: 1.125rem;
         }
-        
+
         .true-test-size-lg {
           font-size: 1.5rem;
         }

--- a/systems/font/weight/_mixin.scss
+++ b/systems/font/weight/_mixin.scss
@@ -1,5 +1,5 @@
-@mixin sparkle-font-weight($true-test: null) {
-  @if $true-test == null {
+@mixin sparkle-font-weight {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---
@@ -14,31 +14,33 @@
     <tbody>
     */
   }
-    @each $key, $value in $font-weight {
-      @if $true-test == null {
-        /* ---
-        section: Systems
-        ---
-        <tr>
-        <td><code>#{settings(prefix)}-weight-#{$key}</code></td>
-        <td><code>weight(#{$key})</code></td>
-        <td><code>#{$key}: #{$value}</td>
-        </tr>
-        */
-      }
-      .#{settings(prefix)}-weight-#{$key} {
-        @include loop-mq {
-          font-weight: $value;
-        }
-      }
-    }
-    @if $true-test == null {
+
+  @each $key, $value in $font-weight {
+    @if $sparkle-show-docs {
       /* ---
       section: Systems
       ---
-      </tbody>
-      </table>
+      <tr>
+      <td><code>#{settings(prefix)}-weight-#{$key}</code></td>
+      <td><code>weight(#{$key})</code></td>
+      <td><code>#{$key}: #{$value}</td>
+      </tr>
       */
     }
+    .#{settings(prefix)}-weight-#{$key} {
+      @include loop-mq {
+        font-weight: $value;
+      }
+    }
   }
+
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    </tbody>
+    </table>
+    */
+  }
+}
   

--- a/systems/font/weight/_test.scss
+++ b/systems/font/weight/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import "mixin";
 
 $font-weight: (
@@ -12,20 +14,18 @@ $settings: (
   'system-font-weight': true
 );
 
-$true-test: true;
-
 @include describe('The Font Weight System') {
   @include it('outputs font-weight classes.') {
     @include assert {
       @include output {
-        @include sparkle-font-weight($true-test);
+        @include sparkle-font-weight;
       }
-      
+
       @include expect {
         .true-test-weight-light {
             font-weight: 200;
         }
-          
+
         .true-test-weight-normal {
           font-weight: 400;
         }

--- a/systems/grid/block/_utility.scss
+++ b/systems/grid/block/_utility.scss
@@ -2,22 +2,24 @@
 
 @if settings(system-grid) {
   $count: grid(columns);
-  /* ---
-  title: Grid System
-  section: Systems
-  ---
+  @if $sparkle-show-docs {
+    /* ---
+    title: Grid System
+    section: Systems
+    ---
 
-  The grid system we are using for page layouts is based on a #{$count} column grid. Grid classes can be nested if needed for more complex layouts.
+    The grid system we are using for page layouts is based on a #{$count} column grid. Grid classes can be nested if needed for more complex layouts.
 
-  Most grid layouts are going to use either a two, three, or four column layout. The basic grid system includes all of the classes needed to create a simple layout with class names that are spelled out and easy to read.
+    Most grid layouts are going to use either a two, three, or four column layout. The basic grid system includes all of the classes needed to create a simple layout with class names that are spelled out and easy to read.
 
-  Each `#{settings(prefix)}-grid-cell-` class can have a responsive suffix to adjust the grid column span a different screen sizes. The #{$count} column count of `#{settings(prefix)}-grid-block` remain persistent at all screen sizes.
+    Each `#{settings(prefix)}-grid-cell-` class can have a responsive suffix to adjust the grid column span a different screen sizes. The #{$count} column count of `#{settings(prefix)}-grid-block` remain persistent at all screen sizes.
 
-  ### Grid Block Class
+    ### Grid Block Class
 
-  To define a grid, an element must have the `#{settings(prefix)}-grid-block` class. This will apply a `display: grid` along with fallback styles for browsers that do not support CSS Grid.
+    To define a grid, an element must have the `#{settings(prefix)}-grid-block` class. This will apply a `display: grid` along with fallback styles for browsers that do not support CSS Grid.
 
-  */
+    */
+  }
   .#{settings(prefix)}-grid-block {
     @include clearfix;
     display: flex;

--- a/systems/grid/cells/_mixins.scss
+++ b/systems/grid/cells/_mixins.scss
@@ -60,15 +60,15 @@
   @else {
     $val: $val;
   }
-  
+
   @return $val;
 }
 
-@mixin sparkle-grid-maker($count:12, $mq:'', $true-test:null) {
+@mixin sparkle-grid-maker($count:12, $mq:'') {
   $class: settings(prefix) + '-grid-cell';
   @for $i from 1 through $count {
     #{sparkle-grid-class($i, $count, $class, $mq)}.#{$class}-#{$i}-#{$count}#{$mq} {
-      @if $true-test == null {
+      @if $sparkle-show-docs {
         /* ---
         section: Systems
         name: grid-demo-#{$i}

--- a/systems/grid/cells/_test.scss
+++ b/systems/grid/cells/_test.scss
@@ -1,4 +1,5 @@
 @import 'true';
+$sparkle-show-docs: false;
 
 @import "mixins";
 
@@ -17,7 +18,7 @@ $media-queries: (
   @include it('outputs grid classes.') {
     @include assert {
       @include output {
-        @include sparkle-grid-maker($count: 8, $true-test: true);
+        @include sparkle-grid-maker($count: 8);
       }
       @include expect {
         .true-test-grid-cell-1-8 {
@@ -31,13 +32,13 @@ $media-queries: (
             grid-column: span 1;
           }
         }
-        
+
         .true-test-grid-cell-quarter,
         .true-test-grid-cell-2-8 {
           float: left;
           width: 25%;
         }
-        
+
         @supports (display: grid) {
           .true-test-grid-cell-quarter,
           .true-test-grid-cell-2-8 {
@@ -45,25 +46,25 @@ $media-queries: (
             grid-column: span 2;
           }
         }
-        
+
         .true-test-grid-cell-3-8 {
           float: left;
           width: 37.5%;
         }
-        
+
         @supports (display: grid) {
           .true-test-grid-cell-3-8 {
             width: auto;
             grid-column: span 3;
           }
         }
-        
+
         .true-test-grid-cell-half,
         .true-test-grid-cell-4-8 {
           float: left;
           width: 50%;
         }
-        
+
         @supports (display: grid) {
           .true-test-grid-cell-half,
           .true-test-grid-cell-4-8 {
@@ -71,26 +72,26 @@ $media-queries: (
             grid-column: span 4;
           }
         }
-        
+
         .true-test-grid-cell-5-8 {
           float: left;
           width: 62.5%;
         }
-        
+
         @supports (display: grid) {
           .true-test-grid-cell-5-8 {
             width: auto;
             grid-column: span 5;
           }
         }
-        
+
         .true-test-grid-cell-three-quarter,
         .true-test-grid-cell-three-quarters,
         .true-test-grid-cell-6-8 {
           float: left;
           width: 75%;
         }
-        
+
         @supports (display: grid) {
           .true-test-grid-cell-three-quarter,
           .true-test-grid-cell-three-quarters,
@@ -99,25 +100,25 @@ $media-queries: (
             grid-column: span 6;
           }
         }
-        
+
         .true-test-grid-cell-7-8 {
           float: left;
           width: 87.5%;
         }
-        
+
         @supports (display: grid) {
           .true-test-grid-cell-7-8 {
             width: auto;
             grid-column: span 7;
           }
         }
-        
+
         .true-test-grid-cell-full,
         .true-test-grid-cell-8-8 {
           float: left;
           width: 100%;
         }
-        
+
         @supports (display: grid) {
           .true-test-grid-cell-full,
           .true-test-grid-cell-8-8 {

--- a/systems/grid/cells/_utility.scss
+++ b/systems/grid/cells/_utility.scss
@@ -1,13 +1,15 @@
 @import "../function";
 @import "mixins";
 
-/* ---
-section: Systems
----
-### Grid Cell Classes
+@if $sparkle-show-docs {
+  /* ---
+  section: Systems
+  ---
+  ### Grid Cell Classes
 
-To define a grid, an element must have the `#{settings(prefix)}-grid-block` class. This will apply a `display: grid` along with fallback styles for browsers that do not support CSS Grid.
-*/
+  To define a grid, an element must have the `#{settings(prefix)}-grid-block` class. This will apply a `display: grid` along with fallback styles for browsers that do not support CSS Grid.
+  */
+}
 
 @if settings(system-grid) {
   $count: grid(columns);
@@ -17,47 +19,52 @@ To define a grid, an element must have the `#{settings(prefix)}-grid-block` clas
     @each $key, $val in $media-queries {
       $mq: '\\@' + $key;
       @media (min-width: #{$val}) {
-        @include sparkle-grid-maker($count, $mq, true);
+        @include sparkle-grid-maker($count, $mq);
       }
     }
   }
-  
+
   @if settings('print-classes') {
     $mq: '\\@print';
     @media print {
-      @include sparkle-grid-maker($count, $mq, true);
+      @include sparkle-grid-maker($count, $mq);
     }
   }
 
-  /* ---
-  section: Systems
-  ---
-  
-  <table>
-  <thead>
-  <tr>
-  <th>Column Span</th>
-  <th>Span Class(es)</th>
-  </tr>
-  </thead>
-  <tbody>
-  */
-  $class: settings(prefix) + '-grid-cell';
-  @for $i from 1 through $count {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---
+    <table>
+    <thead>
     <tr>
-    <td>#{$i}</td>
-    <td>`#{sparkle-grid-class($i, $count, $class, '')}.#{$class}-#{$i}-#{$count}`</td>
+    <th>Column Span</th>
+    <th>Span Class(es)</th>
     </tr>
+    </thead>
+    <tbody>
     */
   }
-  
-  /* ---
-  section: Systems
-  ---
-  </tbody>
-  </table>
-  */
+  $class: settings(prefix) + '-grid-cell';
+  @for $i from 1 through $count {
+    @if $sparkle-show-docs {
+      /* ---
+      section: Systems
+      ---
+      <tr>
+      <td>#{$i}</td>
+      <td>`#{sparkle-grid-class($i, $count, $class, '')}.#{$class}-#{$i}-#{$count}`</td>
+      </tr>
+      */
+    }
+  }
+
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    </tbody>
+    </table>
+    */
+  }
 }

--- a/systems/grid/gap/_mixin.scss
+++ b/systems/grid/gap/_mixin.scss
@@ -1,29 +1,33 @@
 @mixin sparkle-grid-gap {
-  /* ---
-  section: Systems
-  ---
-  
-  ### Grid Gap Classes
-  
-  <table>
-  <thead>
-    <th>Gap Width</th>
-    <th>Class Name</th>
-  </thead>
-  <tbody>
-  <tr>
-    <th colspan="2">Row and Column Gap</th>
-  </tr>
-  */
-  @each $key, $value in $spacer {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---
+
+    ### Grid Gap Classes
+
+    <table>
+    <thead>
+      <th>Gap Width</th>
+      <th>Class Name</th>
+    </thead>
+    <tbody>
     <tr>
-      <td>#{$value}</td>
-      <td>`#{settings(prefix)}-gap-#{$key}`</td>
+      <th colspan="2">Row and Column Gap</th>
     </tr>
     */
+  }
+  @each $key, $value in $spacer {
+    @if $sparkle-show-docs {
+      /* ---
+      section: Systems
+      ---
+      <tr>
+        <td>#{$value}</td>
+        <td>`#{settings(prefix)}-gap-#{$key}`</td>
+      </tr>
+      */
+    }
     .#{settings(prefix)}-gap-#{$key} {
       @include loop-mq {
         grid-gap: $value;
@@ -31,22 +35,26 @@
       }
     }
   }
-  /* ---
-  section: Systems
-  ---
-  <tr>
-    <th colspan="2">Row Gap</th>
-  </tr>
-  */
-  @each $key, $value in $spacer {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---
     <tr>
-      <td>#{$value}</td>
-      <td>`#{settings(prefix)}-gap-row-#{$key}`</td>
+      <th colspan="2">Row Gap</th>
     </tr>
     */
+  }
+  @each $key, $value in $spacer {
+    @if $sparkle-show-docs {
+      /* ---
+      section: Systems
+      ---
+      <tr>
+        <td>#{$value}</td>
+        <td>`#{settings(prefix)}-gap-row-#{$key}`</td>
+      </tr>
+      */
+    }
     .#{settings(prefix)}-gap-row-#{$key} {
       @include loop-mq {
         grid-row-gap: $value;
@@ -54,22 +62,28 @@
       }
     }
   }
-  /* ---
-  section: Systems
-  ---
-  <tr>
-    <th colspan="2">Column Gap</th>
-  </tr>
-  */
-  @each $key, $value in $spacer {
+
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---
     <tr>
-      <td>#{$value}</td>
-      <td>`#{settings(prefix)}-gap-column-#{$key}`</td>
+      <th colspan="2">Column Gap</th>
     </tr>
     */
+  }
+
+  @each $key, $value in $spacer {
+    @if $sparkle-show-docs {
+      /* ---
+      section: Systems
+      ---
+      <tr>
+        <td>#{$value}</td>
+        <td>`#{settings(prefix)}-gap-column-#{$key}`</td>
+      </tr>
+      */
+    }
     .#{settings(prefix)}-gap-column-#{$key} {
       @include loop-mq {
         grid-column-gap: $value;
@@ -77,10 +91,12 @@
       }
     }
   }
-  /* ---
-  section: Systems
-  ---
-  </tbody>
-  </table>
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    </tbody>
+    </table>
+    */
+  }
 }

--- a/systems/spacing/_docs.scss
+++ b/systems/spacing/_docs.scss
@@ -1,42 +1,48 @@
-/* ---
-title: Spacing System
-section: Systems
----
-
-### Spacing System Function
-
-The spacing system function allows you to load the determined spacing value by calling the `space()` function with the size key.
-
-```css
-.my-class {
-  margin-left: space(md);
-}
-```
-
-Below is the spacing system value options and the spacing size.
-
-<table>
-<thead>
-<th>Function</th>
-<th>Size</th>
-</thead>
-<tbody>
-*/
-
-@each $space-key, $space-val in $spacer {
+@if $sparkle-show-docs {
   /* ---
+  title: Spacing System
   section: Systems
   ---
-  <tr>
-  <td><code>space(#{$space-key})</code></td>
-  <td><code>#{$space-val}</code></td>
-  </tr>
+
+  ### Spacing System Function
+
+  The spacing system function allows you to load the determined spacing value by calling the `space()` function with the size key.
+
+  ```css
+  .my-class {
+    margin-left: space(md);
+  }
+  ```
+
+  Below is the spacing system value options and the spacing size.
+
+  <table>
+  <thead>
+  <th>Function</th>
+  <th>Size</th>
+  </thead>
+  <tbody>
   */
 }
 
-/* ---
-section: Systems
----
-</tbody>
-</table>
-*/
+@each $space-key, $space-val in $spacer {
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    <tr>
+    <td><code>space(#{$space-key})</code></td>
+    <td><code>#{$space-val}</code></td>
+    </tr>
+    */
+  }
+}
+
+@if $sparkle-show-docs {
+  /* ---
+  section: Systems
+  ---
+  </tbody>
+  </table>
+  */
+}

--- a/systems/spacing/_mixins.scss
+++ b/systems/spacing/_mixins.scss
@@ -23,7 +23,7 @@
   }
 }
 
-@mixin sparkle-spacing-side-loop($type, $mq:null, $true-test:null) {
+@mixin sparkle-spacing-side-loop($type, $mq:null) {
   $type-name: $type;
   @if $mq {
     $mq: '\\@' + $mq;
@@ -33,8 +33,8 @@
   }
   @each $side-key, $side-val in $sides {
     @each $space-key, $space-val in $spacer {
-      @if $true-test == null {
-        @if $mq == null {
+      @if $mq == null {
+        @if $sparkle-show-docs {
           /* ---
           section: Systems
           ---
@@ -54,8 +54,8 @@
   }
 }
 
-@mixin sparkle-spacing-loop($type, $true-test:null) {
-  @if $true-test == null {
+@mixin sparkle-spacing-loop($type) {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---
@@ -70,18 +70,19 @@
     <tbody>
     */
   }
-  @include sparkle-spacing-side-loop($type, null, $true-test);
+
+  @include sparkle-spacing-side-loop($type);
   @each $key, $val in $media-queries {
     @media (min-width: #{$val}) {
-      @include sparkle-spacing-side-loop($type, $key, $true-test);
+      @include sparkle-spacing-side-loop($type, $key);
     }
   }
   @if settings('print-classes') {
     @media print {
-      @include sparkle-spacing-side-loop($type, print, $true-test);
+      @include sparkle-spacing-side-loop($type, print);
     }
   }
-  @if $true-test == null {
+  @if $sparkle-show-docs {
     /* ---
     section: Systems
     ---

--- a/systems/spacing/margin/_test.scss
+++ b/systems/spacing/margin/_test.scss
@@ -1,4 +1,5 @@
 @import 'true';
+$sparkle-show-docs: false;
 
 @import "../mixins";
 
@@ -31,7 +32,7 @@ $media-queries: (
   @include it('outputs regular spacing classes.') {
     @include assert {
       @include output {
-        @include sparkle-spacing-loop(margin, true);
+        @include sparkle-spacing-loop(margin);
       }
       @include expect {
         .true-test-margin-all-sm {

--- a/systems/spacing/margin/_utility.scss
+++ b/systems/spacing/margin/_utility.scss
@@ -1,12 +1,13 @@
 @import "../mixins";
 @if settings(utility-margin) {
-  /* ---
-  section: Systems
-  ---
-  
-  ### Margin Utility Classes
-  
-  The margin spacing utility classes apply spacing system value size to the defined side on the outside of the container.
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    ### Margin Utility Classes
+
+    The margin spacing utility classes apply spacing system value size to the defined side on the outside of the container.
+    */
+  }
   @include sparkle-spacing-loop(margin);
 }

--- a/systems/spacing/padding/_test.scss
+++ b/systems/spacing/padding/_test.scss
@@ -1,4 +1,5 @@
 @import 'true';
+$sparkle-show-docs: false;
 
 @import "../mixins";
 
@@ -31,7 +32,7 @@ $media-queries: (
   @include it('outputs regular spacing classes.') {
     @include assert {
       @include output {
-        @include sparkle-spacing-loop(padding, true);
+        @include sparkle-spacing-loop(padding);
       }
       @include expect {
         .true-test-pad-all-sm {

--- a/systems/spacing/padding/_utility.scss
+++ b/systems/spacing/padding/_utility.scss
@@ -1,12 +1,14 @@
 @import "../mixins";
 @if settings(utility-padding) {
-  /* ---
-  section: Systems
-  ---
-  
-  ### Padding Utility Classes
-  
-  The padding spacing utility classes apply spacing system value size to the defined side on the inside of the container.
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+
+    ### Padding Utility Classes
+
+    The padding spacing utility classes apply spacing system value size to the defined side on the inside of the container.
+    */
+  }
   @include sparkle-spacing-loop(padding);
 }

--- a/systems/spacing/position/_test.scss
+++ b/systems/spacing/position/_test.scss
@@ -1,4 +1,5 @@
 @import 'true';
+$sparkle-show-docs: false;
 
 @import "../mixins";
 
@@ -31,7 +32,7 @@ $media-queries: (
   @include it('outputs regular spacing classes.') {
     @include assert {
       @include output {
-        @include sparkle-spacing-loop(position, true);
+        @include sparkle-spacing-loop(position);
       }
       @include expect {
         .true-test-position-all-sm {

--- a/systems/spacing/position/_utility.scss
+++ b/systems/spacing/position/_utility.scss
@@ -1,13 +1,15 @@
 @import "../mixins";
 @if settings(utility-position-spacing) {
-  /* ---
-  section: Systems
-  ---
-  
-  ### Position Spacing Utility Classes
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
 
-  The position spacing utility classes should be used in conjunction with the position utility classes. These classes apply spacing system value size to the defined side.
+    ### Position Spacing Utility Classes
 
-  */
+    The position spacing utility classes should be used in conjunction with the position utility classes. These classes apply spacing system value size to the defined side.
+
+    */
+  }
   @include sparkle-spacing-loop(position);
 }

--- a/systems/z-index/_utility.scss
+++ b/systems/z-index/_utility.scss
@@ -1,32 +1,34 @@
 @if settings('utility-z-index') {
-  /* ---
-section: Systems
-title: Z-Index System
----
-
-<table>
-<thead>
-<tr>
-<th>Property Value</th>
-<th>Class</th>
-<th>Function</th>
-</tr>
-</thead>
-<tbody>
-
-*/
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    title: Z-Index System
+    ---
+    <table>
+    <thead>
+    <tr>
+    <th>Property Value</th>
+    <th>Class</th>
+    <th>Function</th>
+    </tr>
+    </thead>
+    <tbody>
+    */
+  }
 
   @each $key, $value in $z-index {
-    /* ---
-section: Systems
----
+    @if $sparkle-show-docs {
+      /* ---
+      section: Systems
+      ---
+      <tr>
+        <td>#{$value}</td>
+        <td>`.#{settings(prefix)}-z-index-#{$key}`</td>
+        <td>`z-index(#{$key})`</td>
+      </tr>
+      */
+    }
 
-<tr>
-  <td>#{$value}</td>
-  <td>`.#{settings(prefix)}-z-index-#{$key}`</td>
-  <td>`z-index(#{$key})`</td>
-</tr>
-*/
     .#{settings(prefix)}-z-index-#{$key} {
       @include loop-mq {
         z-index: $value;
@@ -34,11 +36,12 @@ section: Systems
     }
   }
 
-  /* ---
-section: Systems
----
-
-</tbody>
-</table>
-*/
+  @if $sparkle-show-docs {
+    /* ---
+    section: Systems
+    ---
+    </tbody>
+    </table>
+    */
+  }
 }

--- a/tools/antialiased/_mixin.scss
+++ b/tools/antialiased/_mixin.scss
@@ -1,28 +1,27 @@
-/* ---
-title: Anti-aliased Mixin
-section: Tools
----
-
-Adds font smoothing properties.
-
-**Use**
-```scss
-.my-class {
-  @include antialiased;
+@if $sparkle-show-docs {
+  /* ---
+  title: Anti-aliased Mixin
+  section: Tools
+  ---
+  Adds font smoothing properties.
+  **Use**
+  ```scss
+  .my-class {
+    @include antialiased;
+  }
+  ```
+  **CSS Output**
+  ```css
+  .my-class {
+    -moz-osx-font-smoothing: antialiased;
+    -webkit-font-smoothing: antialiased;
+  }
+  ```
+  */
 }
-```
-
-**CSS Output**
-```css
-.my-class {
-  -moz-osx-font-smoothing: antialiased;
-  -webkit-font-smoothing: antialiased;
-}
-```
-
-*/
 
 @mixin antialiased {
   -moz-osx-font-smoothing: antialiased;
   -webkit-font-smoothing: antialiased;
 }
+

--- a/tools/antialiased/_test.scss
+++ b/tools/antialiased/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 
 @include describe('The antialiased mixin') {

--- a/tools/antialiased/_utility.scss
+++ b/tools/antialiased/_utility.scss
@@ -1,14 +1,16 @@
-/* ---
-title: Anti-aliased Utility
-section: Utilities
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Anti-aliased Utility
+  section: Utilities
+  ---
 
-Smooths the font on the level of the pixel.
+  Smooths the font on the level of the pixel.
 
-```scss
-.#{settings(prefix)}-antialiased
-```
-*/
+  ```scss
+  .#{settings(prefix)}-antialiased
+  ```
+  */
+}
 
 .#{settings(prefix)}-antialiased {
   @include antialiased;

--- a/tools/clearfix/_mixin.scss
+++ b/tools/clearfix/_mixin.scss
@@ -1,25 +1,27 @@
-/* ---
-title: Clearfix Mixin
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Clearfix Mixin
+  section: Tools
+  ---
 
-**Use**
-```scss
-.my-class {
-  @include clearfix;
+  **Use**
+  ```scss
+  .my-class {
+    @include clearfix;
+  }
+  ```
+
+  **CSS Output**
+  ```css
+  .my-class::after {
+    clear: both;
+    content: "";
+    display: table;
+  }
+  ```
+
+  */
 }
-```
-
-**CSS Output**
-```css
-.my-class::after {
-  clear: both;
-  content: "";
-  display: table;
-}
-```
-
-*/
 @mixin clearfix {
   &::after {
     clear: both;
@@ -27,3 +29,4 @@ section: Tools
     display: table;
   }
 }
+

--- a/tools/clearfix/_test.scss
+++ b/tools/clearfix/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 
 @include describe('The clearfix mixin') {

--- a/tools/clearfix/_utility.scss
+++ b/tools/clearfix/_utility.scss
@@ -1,15 +1,14 @@
-/* ---
-title: Clearfix Utility
-section: Utilities
----
-
-Prevents an element from collapsing due to margins for floated contents.
-
-```scss
-.#{settings(prefix)}-clearfix
-```
-*/
-
+@if $sparkle-show-docs {
+  /* ---
+  title: Clearfix Utility
+  section: Utilities
+  ---
+  Prevents an element from collapsing due to margins for floated contents.
+  ```scss
+  .#{settings(prefix)}-clearfix
+  ```
+  */
+}
 .#{settings(prefix)}-clearfix {
   @include clearfix;
 }

--- a/tools/delink/_mixin.scss
+++ b/tools/delink/_mixin.scss
@@ -1,26 +1,27 @@
-/* ---
-title: Delink Mixin
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Delink Mixin
+  section: Tools
+  ---
 
-Removes default link styles.
+  Removes default link styles.
 
-**Use**
-```scss
-.my-class {
-  @include delink;
+  **Use**
+  ```scss
+  .my-class {
+    @include delink;
+  }
+  ```
+
+  **CSS Output**
+  ```css
+  .my-class {
+    color: inherit;
+    text-decoration: none;
+  }
+  ```
+  */
 }
-```
-
-**CSS Output**
-```css
-.my-class {
-  color: inherit;
-  text-decoration: none;
-}
-```
-
-*/
 
 @mixin delink {
   color: inherit;

--- a/tools/delink/_test.scss
+++ b/tools/delink/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 
 @include describe('The delink mixin') {

--- a/tools/delink/_utility.scss
+++ b/tools/delink/_utility.scss
@@ -1,14 +1,15 @@
-/* ---
-title: Delink Utility
-section: Utilities
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Delink Utility
+  section: Utilities
+  ---
+  Removes link styles from and element.
 
-Removes link styles from and element.
-
-```scss
-.#{settings(prefix)}-delink
-```
-*/
+  ```scss
+  .#{settings(prefix)}-delink
+  ```
+  */
+}
 .#{settings(prefix)}-delink {
   @include delink;
 }

--- a/tools/delist/_mixin.scss
+++ b/tools/delist/_mixin.scss
@@ -1,28 +1,28 @@
-/* ---
-title: Delist Mixin
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Delist Mixin
+  section: Tools
+  ---
 
-Removes default list styles.
+  Removes default list styles.
 
-**Use**
-```scss
-.my-class {
-  @include delist;
+  **Use**
+  ```scss
+  .my-class {
+    @include delist;
+  }
+  ```
+
+  **CSS Output**
+  ```css
+  .my-class {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  ```
+  */
 }
-```
-
-**CSS Output**
-```css
-.my-class {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-```
-
-*/
-
 @mixin delist {
   margin: 0;
   padding: 0;

--- a/tools/delist/_test.scss
+++ b/tools/delist/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 
 @include describe('The delist mixin') {

--- a/tools/delist/_utility.scss
+++ b/tools/delist/_utility.scss
@@ -1,15 +1,16 @@
-/* ---
-title: Delist Utility
-section: Utilities
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Delist Utility
+  section: Utilities
+  ---
+  Removes the list styles from ordered and unordered lists.
 
-Removes the list styles from ordered and unordered lists.
+  ```scss
+  .#{settings(prefix)}-delist
+  ```
 
-```scss
-.#{settings(prefix)}-delist
-```
-
-*/
+  */
+}
 .#{settings(prefix)}-delist {
   @include delist;
 }

--- a/tools/loop-mq/_mixin.scss
+++ b/tools/loop-mq/_mixin.scss
@@ -1,58 +1,60 @@
-/* ---
-title: Loop Media Query Mixin
-name: loop-mq-mixin
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Loop Media Query Mixin
+  name: loop-mq-mixin
+  section: Tools
+  ---
 
-Auto-generates media queries for looping content.
+  Auto-generates media queries for looping content.
 
-**Use**
-```scss
-.my-class {
-  @include loop-mq {
-    prop: value;
+  **Use**
+  ```scss
+  .my-class {
+    @include loop-mq {
+      prop: value;
+    }
   }
-}
-```
+  ```
 
-**Use with a prop**
-```scss
-.my-class {
-  @include loop-mq {
+  **Use with a prop**
+  ```scss
+  .my-class {
+    @include loop-mq {
+      margin: 1rem;
+    }
+  }
+  ```
+
+  **CSS Output**
+  ```css
+  .my-class {
     margin: 1rem;
   }
-}
-```
-
-**CSS Output**
-```css
-.my-class {
-  margin: 1rem;
-}
-@media (min-width: 40rem) {
-  .my-class\@sm {
-    margin: 1rem;
+  @media (min-width: 40rem) {
+    .my-class\@sm {
+      margin: 1rem;
+    }
   }
-}
-@media (min-width: 60rem) {
-  .my-class\@md {
-    margin: 1rem;
+  @media (min-width: 60rem) {
+    .my-class\@md {
+      margin: 1rem;
+    }
   }
-}
-@media (min-width: 80rem) {
-  .my-class\@lg {
-    margin: 1rem;
+  @media (min-width: 80rem) {
+    .my-class\@lg {
+      margin: 1rem;
+    }
   }
+  ```
+
+  **Note:** when using these classes in HTML, the `@` does not need to be escaped. Here's an example:
+
+  ```
+  <p class="my-class@lg">No need to escape the @ symbol</p>
+  ```
+
+  */
 }
-```
-
-**Note:** when using these classes in HTML, the `@` does not need to be escaped. Here's an example:
-
-```
-<p class="my-class@lg">No need to escape the @ symbol</p>
-```
-
-*/
 
 @mixin loop-mq {
   @content;

--- a/tools/loop-mq/_test.scss
+++ b/tools/loop-mq/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 
 $settings: (

--- a/tools/negative/_function.scss
+++ b/tools/negative/_function.scss
@@ -1,32 +1,33 @@
-/* ---
-title: Negative Function
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Negative Function
+  section: Tools
+  ---
 
-Turns a positive number into a negative number. This comes in handy when a variable is passed in, so `-$value` becomes explicit `negative($value)`.
+  Turns a positive number into a negative number. This comes in handy when a variable is passed in, so `-$value` becomes explicit `negative($value)`.
 
-**Use**
-```scss
-.test-class {
-  prop: negative(<number>);
+  **Use**
+  ```scss
+  .test-class {
+    prop: negative(<number>);
+  }
+  ```
+
+  **Use with a prop**
+  ```scss
+  .test-class {
+    margin: negative(1rem);
+  }
+  ```
+
+  **CSS Output**
+  ```css
+  .test-class {
+    margin: -1rem;
+  }
+  ```
+  */
 }
-```
-
-**Use with a prop**
-```scss
-.test-class {
-  margin: negative(1rem);
-}
-```
-
-**CSS Output**
-```css
-.test-class {
-  margin: -1rem;
-}
-```
-
-*/
 
 @function negative($value) {
   @if ($value > 0) {

--- a/tools/negative/_test.scss
+++ b/tools/negative/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'function';
 
 @include describe('The negative function') {

--- a/tools/print-mq/_mixin.scss
+++ b/tools/print-mq/_mixin.scss
@@ -1,57 +1,57 @@
-/* ---
-title: Print Mixin
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Print Mixin
+  section: Tools
+  ---
 
-Provides two functionalities. The first is to hide the element when printed.
+  Provides two functionalities. The first is to hide the element when printed.
 
-**Use**
-```scss
-.my-class {
-  @include print(hide);
-}
-```
-
-**CSS Output**
-```css
-@media (print) {
+  **Use**
+  ```scss
   .my-class {
-    display: none !important;
+    @include print(hide);
   }
-}
-```
+  ```
 
-
-The second functionality is to provide custom styles when printed.
-
-**Use**
-```scss
-.my-class {
-  @include print {
-    prop: value;
+  **CSS Output**
+  ```css
+  @media (print) {
+    .my-class {
+      display: none !important;
+    }
   }
-}
-```
+  ```
 
-**Use with a prop**
-```scss
-.my-class {
-  @include print {
-    background-color: black;
-  }
-}
-```
+  The second functionality is to provide custom styles when printed.
 
-**CSS Output**
-```css
-@media print {
+  **Use**
+  ```scss
   .my-class {
-    background-color: black;
+    @include print {
+      prop: value;
+    }
   }
-}
-```
+  ```
 
-*/
+  **Use with a prop**
+  ```scss
+  .my-class {
+    @include print {
+      background-color: black;
+    }
+  }
+  ```
+
+  **CSS Output**
+  ```css
+  @media print {
+    .my-class {
+      background-color: black;
+    }
+  }
+  ```
+  */
+}
 
 @mixin print($state:null) {
   @media print {

--- a/tools/print-mq/_test.scss
+++ b/tools/print-mq/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 
 @include describe('The print mixin') {

--- a/tools/ratio/_function.scss
+++ b/tools/ratio/_function.scss
@@ -1,32 +1,34 @@
-/* ---
-title: Ratio Function
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Ratio Function
+  section: Tools
+  ---
 
-Creates a ratio percentage value when given a height value and width value.
+  Creates a ratio percentage value when given a height value and width value.
 
-**Use**
-```scss
-.my-class {
-  prop: ratio(<height>, <width>);
+  **Use**
+  ```scss
+  .my-class {
+    prop: ratio(<height>, <width>);
+  }
+  ```
+
+  **Use with a prop**
+  ```scss
+  .my-class {
+    width: ratio(200, 400);
+  }
+  ```
+
+  **CSS Output**
+  ```css
+  .my-class {
+    width: 50%;
+  }
+  ```
+  */
 }
-```
 
-**Use with a prop**
-```scss
-.my-class {
-  width: ratio(200, 400);
-}
-```
-
-**CSS Output**
-```css
-.my-class {
-  width: 50%;
-}
-```
-
-*/
 @function ratio($height,$width) {
   @return ($height / $width) * 100%;
 }

--- a/tools/ratio/_test.scss
+++ b/tools/ratio/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'function';
 
 @include describe('The ratio function') {

--- a/tools/remify/_function.scss
+++ b/tools/remify/_function.scss
@@ -1,32 +1,33 @@
-/* ---
-title: Remify Function
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Remify Function
+  section: Tools
+  ---
 
-Converts a number to a rem value.
+  Converts a number to a rem value.
 
-**Use**
-```scss
-.my-class {
-  prop: remify(<number>);
+  **Use**
+  ```scss
+  .my-class {
+    prop: remify(<number>);
+  }
+  ```
+
+  **Use with a prop**
+  ```scss
+  .my-class {
+    margin: remify(24);
+  }
+  ```
+
+  **CSS Output**
+  ```css
+  .my-class {
+    margin: 1.5rem;
+  }
+  ```
+  */
 }
-```
-
-**Use with a prop**
-```scss
-.my-class {
-  margin: remify(24);
-}
-```
-
-**CSS Output**
-```css
-.my-class {
-  margin: 1.5rem;
-}
-```
-
-*/
 
 @function remify($value) {
   $value: strip-units($value);

--- a/tools/remify/_test.scss
+++ b/tools/remify/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'function';
 @import '../strip-units/function';
 

--- a/tools/settings/_test.scss
+++ b/tools/settings/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'function';
 
 $settings: (

--- a/tools/stringify/_function.scss
+++ b/tools/stringify/_function.scss
@@ -1,32 +1,33 @@
-/* ---
-title: Stringify Function
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Stringify Function
+  section: Tools
+  ---
 
-Converts a number to a string.
+  Converts a number to a string.
 
-**Use**
-```scss
-.my-class {
-  prop: stringify(<number>);
+  **Use**
+  ```scss
+  .my-class {
+    prop: stringify(<number>);
+  }
+  ```
+
+  **Use with a prop**
+  ```scss
+  .my-class::before {
+    content: stringify(6);
+  }
+  ```
+
+  **CSS Output**
+  ```css
+  .my-class::before {
+    content: '6';
+  }
+  ```
+  */
 }
-```
-
-**Use with a prop**
-```scss
-.my-class::before {
-  content: stringify(6);
-}
-```
-
-**CSS Output**
-```css
-.my-class::before {
-  content: '6';
-}
-```
-
-*/
 
 @function stringify($value) {
   @return $value + '';

--- a/tools/stringify/_test.scss
+++ b/tools/stringify/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'function';
 
 @include describe('The stringify function') {

--- a/tools/strip-units/_function.scss
+++ b/tools/strip-units/_function.scss
@@ -1,17 +1,18 @@
-/* ---
-title: Strip Units Function
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Strip Units Function
+  section: Tools
+  ---
+  Removes the unit of number. This is handy for maths in mixins/functions, for example if you need to check to values of two numbers. If one is a `em` value and the other is a `rem` value, you have to strip the units to accomplish the math.
 
-Removes the unit of number. This is handy for maths in mixins/functions, for example if you need to check to values of two numbers. If one is a `em` value and the other is a `rem` value, you have to strip the units to accomplish the math.
-
-**Use**
-```scss
-.my-class {
-  prop: strip-units(<number>);
+  **Use**
+  ```scss
+  .my-class {
+    prop: strip-units(<number>);
+  }
+  ```
+  */
 }
-```
-*/
 
 @function strip-units($number) {
   @return $number / ($number * 0 + 1);

--- a/tools/strip-units/_test.scss
+++ b/tools/strip-units/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'function';
 
 @include describe('The strip units function') {

--- a/tools/unbuttonize/_mixin.scss
+++ b/tools/unbuttonize/_mixin.scss
@@ -1,33 +1,34 @@
-/* ---
-title: Unbuttonize Mixin
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Unbuttonize Mixin
+  section: Tools
+  ---
 
-Removes styles added by default to button elements. For when something should semantically be a button, but isn't buttony in appearance.
+  Removes styles added by default to button elements. For when something should semantically be a button, but isn't buttony in appearance.
 
-**Use**
-```scss
-.my-class {
-  @include unbuttonize;
+  **Use**
+  ```scss
+  .my-class {
+    @include unbuttonize;
+  }
+  ```
+
+  **CSS Output**
+  ```css
+  .my-class {
+    background-color: transparent;
+    color: inherit;
+    border: none;
+    margin: 0;
+    padding: 0;
+    text-align: inherit;
+    font: inherit;
+    border-radius: 0;
+    appearance: none;
+  }
+  ```
+  */
 }
-```
-
-**CSS Output**
-```css
-.my-class {
-  background-color: transparent;
-  color: inherit;
-  border: none;
-  margin: 0;
-  padding: 0;
-  text-align: inherit;
-  font: inherit;
-  border-radius: 0;
-  appearance: none;
-}
-```
-
-*/
 
 @mixin unbuttonize {
   background-color: transparent;

--- a/tools/unbuttonize/_test.scss
+++ b/tools/unbuttonize/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 
 @include describe('The unbuttonize mixin') {

--- a/tools/unbuttonize/_utility.scss
+++ b/tools/unbuttonize/_utility.scss
@@ -1,14 +1,17 @@
-/* ---
-title: Unbuttonize Utility
-section: Utilities
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Unbuttonize Utility
+  section: Utilities
+  ---
 
-Removes styles added by default to button elements.
+  Removes styles added by default to button elements.
 
-```scss
-.#{settings(prefix)}-unbuttonize
-```
-*/
+  ```scss
+  .#{settings(prefix)}-unbuttonize
+  ```
+  */
+}
+
 .#{settings(prefix)}-unbuttonize {
   @include unbuttonize;
 }

--- a/tools/visually-hidden/_mixin.scss
+++ b/tools/visually-hidden/_mixin.scss
@@ -1,26 +1,27 @@
-/* ---
-title: Visually Hidden Mixin
-section: Tools
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Visually Hidden Mixin
+  section: Tools
+  ---
 
-Hides an element visually, but still accessible to screen readers.
+  Hides an element visually, but still accessible to screen readers.
 
-**Use**
-```scss
-.my-class {
-  @include visually-hidden;
+  **Use**
+  ```scss
+  .my-class {
+    @include visually-hidden;
+  }
+  ```
+
+  **CSS Output**
+  ```css
+  .my-class {
+    position: fixed;
+    clip: rect(0, 0, 0, 0);
+  }
+  ```
+  */
 }
-```
-
-**CSS Output**
-```css
-.my-class {
-  position: fixed;
-  clip: rect(0, 0, 0, 0);
-}
-```
-
-*/
 
 @mixin visually-hidden {
   position: fixed;

--- a/tools/visually-hidden/_test.scss
+++ b/tools/visually-hidden/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 
 @include describe('The visually-hidden mixin') {

--- a/utilities/align-items/_test.scss
+++ b/utilities/align-items/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -21,7 +23,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-align-items();
+        @include sparkle-align-items;
       }
       @include expect {
         .util-align-items-center {

--- a/utilities/align-items/_utility.scss
+++ b/utilities/align-items/_utility.scss
@@ -1,37 +1,39 @@
 @import "mixin";
 
 @if settings(utility-align-items) {
-  /* ---
-  title: Align Items Utility
-  section: Utilities
-  ---
-  <table>
-  <thead>
-  <tr>
-  <th>Class Name</th>
-  <th>Property</th>
-  </thead>
-  <tbody>
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    title: Align Items Utility
+    section: Utilities
+    ---
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-  // NOTE: This @each loop is only for document generation
-  @each $value in $util-align-items-values {
+    // NOTE: This @each loop is only for document generation
+    @each $value in $util-align-items-values {
+      /* ---
+      section: Utilities
+      ---
+      <tr>
+      <td>`.#{settings(prefix)}-align-items-#{$value}`</td>
+      <td>`align-items: #{$value}`</td>
+      </tr>
+      */
+    }
+
     /* ---
     section: Utilities
     ---
-    <tr>
-    <td>`.#{settings(prefix)}-align-items-#{$value}`</td>
-    <td>`align-items: #{$value}`</td>
-    </tr>
+    </tbody>
+    </table>
     */
   }
-
-  /* ---
-  section: Utilities
-  ---
-  </tbody>
-  </table>
-  */
 
   // Load the mixin
   @include sparkle-align-items;

--- a/utilities/align-self/_test.scss
+++ b/utilities/align-self/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -21,7 +23,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-align-self();
+        @include sparkle-align-self;
       }
       @include expect {
         .util-align-self-center {

--- a/utilities/align-self/_utility.scss
+++ b/utilities/align-self/_utility.scss
@@ -1,37 +1,39 @@
 @import "mixin";
 
 @if settings(utility-align-self) {
-  /* ---
-  title: Align Self Utility
-  section: Utilities
-  ---
-  <table>
-  <thead>
-  <tr>
-  <th>Class Name</th>
-  <th>Property</th>
-  </thead>
-  <tbody>
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    title: Align Self Utility
+    section: Utilities
+    ---
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-  // NOTE: This @each loop is only for document generation
-  @each $value in $util-align-self-values {
+    // NOTE: This @each loop is only for document generation
+    @each $value in $util-align-self-values {
+      /* ---
+      section: Utilities
+      ---
+      <tr>
+      <td>`.#{settings(prefix)}-align-self-#{$value}`</td>
+      <td>`align-self: #{$value}`</td>
+      </tr>
+      */
+    }
+
     /* ---
     section: Utilities
     ---
-    <tr>
-    <td>`.#{settings(prefix)}-align-self-#{$value}`</td>
-    <td>`align-self: #{$value}`</td>
-    </tr>
+    </tbody>
+    </table>
     */
   }
-
-  /* ---
-  section: Utilities
-  ---
-  </tbody>
-  </table>
-  */
 
   // Load the mixin
   @include sparkle-align-self;

--- a/utilities/display/_test.scss
+++ b/utilities/display/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/loop-mq/mixin';
 @import '../../tools/settings/function';
@@ -20,7 +22,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-display();
+        @include sparkle-display;
       }
       @include expect {
         .util-display-none {

--- a/utilities/display/_utility.scss
+++ b/utilities/display/_utility.scss
@@ -1,40 +1,41 @@
 @import "mixin";
 
 @if settings(utility-display) {
-  /* ---
-title: Display Utility
-section: Utilities
----
-
-<table>
-<thead>
-<tr>
-<th>Class Name</th>
-<th>Property</th>
-</thead>
-<tbody>
-*/
-
-  // NOTE: This @each loop is only for document generation
-  @each $value in $util-display-values {
+  @if $sparkle-show-docs {
     /* ---
-section: Utilities
----
+    title: Display Utility
+    section: Utilities
+    ---
 
-<tr>
-<td>`.#{settings(prefix)}-display-#{$value}`</td>
-<td>`display: #{$value}`</td>
-</tr>
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-*/
+    // NOTE: This @each loop is only for document generation
+    @each $value in $util-display-values {
+      /* ---
+      section: Utilities
+      ---
+
+      <tr>
+      <td>`.#{settings(prefix)}-display-#{$value}`</td>
+      <td>`display: #{$value}`</td>
+      </tr>
+      */
+    }
+
+    /* ---
+    section: Utilities
+    ---
+    </tbody>
+    </table>
+    */
   }
-
-  /* ---
-section: Utilities
----
-</tbody>
-</table>
-*/
 
   // Load the mixin
   @include sparkle-display;

--- a/utilities/flex-direction/_test.scss
+++ b/utilities/flex-direction/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -21,7 +23,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-flex-direction();
+        @include sparkle-flex-direction;
       }
       @include expect {
         .util-flex-row {

--- a/utilities/flex-direction/_utility.scss
+++ b/utilities/flex-direction/_utility.scss
@@ -1,37 +1,39 @@
 @import "mixin";
 
 @if settings(utility-flex-direction) {
-  /* ---
-  title: Flex Direction Utility
-  section: Utilities
-  ---
-  <table>
-  <thead>
-  <tr>
-  <th>Class Name</th>
-  <th>Property</th>
-  </thead>
-  <tbody>
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    title: Flex Direction Utility
+    section: Utilities
+    ---
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-  // NOTE: This @each loop is only for document generation
-  @each $value in $util-flex-direction-values {
+    // NOTE: This @each loop is only for document generation
+    @each $value in $util-flex-direction-values {
+      /* ---
+      section: Utilities
+      ---
+      <tr>
+      <td>`.#{settings(prefix)}-flex-#{$value}`</td>
+      <td>`flex-direction: #{$value}`</td>
+      </tr>
+      */
+    }
+
     /* ---
     section: Utilities
     ---
-    <tr>
-    <td>`.#{settings(prefix)}-flex-#{$value}`</td>
-    <td>`flex-direction: #{$value}`</td>
-    </tr>
+    </tbody>
+    </table>
     */
   }
-
-  /* ---
-  section: Utilities
-  ---
-  </tbody>
-  </table>
-  */
 
   // Load the mixin
   @include sparkle-flex-direction;

--- a/utilities/flex-grow/_test.scss
+++ b/utilities/flex-grow/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -16,7 +18,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-flex-grow();
+        @include sparkle-flex-grow;
       }
       @include expect {
         .util-flex-grow-0 {

--- a/utilities/flex-grow/_utility.scss
+++ b/utilities/flex-grow/_utility.scss
@@ -1,37 +1,39 @@
 @import "mixin";
 
 @if settings(utility-flex-grow) {
-  /* ---
-  title: Flex Grow Utility
-  section: Utilities
-  ---
-  <table>
-  <thead>
-  <tr>
-  <th>Class Name</th>
-  <th>Property</th>
-  </thead>
-  <tbody>
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    title: Flex Grow Utility
+    section: Utilities
+    ---
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-  // NOTE: This @for loop is only for document generation
-  @for $value from 0 through 2 {
+    // NOTE: This @for loop is only for document generation
+    @for $value from 0 through 2 {
+      /* ---
+      section: Utilities
+      ---
+      <tr>
+      <td>`.#{settings(prefix)}-flex-grow-#{$value}`</td>
+      <td>`flex-grow: #{$value}`</td>
+      </tr>
+      */
+    }
+
     /* ---
     section: Utilities
     ---
-    <tr>
-    <td>`.#{settings(prefix)}-flex-grow-#{$value}`</td>
-    <td>`flex-grow: #{$value}`</td>
-    </tr>
+    </tbody>
+    </table>
     */
   }
-
-  /* ---
-  section: Utilities
-  ---
-  </tbody>
-  </table>
-  */
 
   // Load the mixin
   @include sparkle-flex-grow;

--- a/utilities/flex-shrink/_test.scss
+++ b/utilities/flex-shrink/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -16,7 +18,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-flex-shrink();
+        @include sparkle-flex-shrink;
       }
       @include expect {
         .util-flex-shrink-0 {

--- a/utilities/flex-shrink/_utility.scss
+++ b/utilities/flex-shrink/_utility.scss
@@ -1,37 +1,39 @@
 @import "mixin";
 
 @if settings(utility-flex-shrink) {
-  /* ---
-  title: Flex Shrink Utility
-  section: Utilities
-  ---
-  <table>
-  <thead>
-  <tr>
-  <th>Class Name</th>
-  <th>Property</th>
-  </thead>
-  <tbody>
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    title: Flex Shrink Utility
+    section: Utilities
+    ---
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-  // NOTE: This @for loop is only for document generation
-  @for $value from 0 through 2 {
+    // NOTE: This @for loop is only for document generation
+    @for $value from 0 through 2 {
+      /* ---
+      section: Utilities
+      ---
+      <tr>
+      <td>`.#{settings(prefix)}-flex-shrink-#{$value}`</td>
+      <td>`flex-shrink: #{$value}`</td>
+      </tr>
+      */
+    }
+
     /* ---
     section: Utilities
     ---
-    <tr>
-    <td>`.#{settings(prefix)}-flex-shrink-#{$value}`</td>
-    <td>`flex-shrink: #{$value}`</td>
-    </tr>
+    </tbody>
+    </table>
     */
   }
-
-  /* ---
-  section: Utilities
-  ---
-  </tbody>
-  </table>
-  */
 
   // Load the mixin
   @include sparkle-flex-shrink;

--- a/utilities/flex-wrap/_test.scss
+++ b/utilities/flex-wrap/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -21,7 +23,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-flex-wrap();
+        @include sparkle-flex-wrap;
       }
       @include expect {
         .util-flex-wrap {

--- a/utilities/flex-wrap/_utility.scss
+++ b/utilities/flex-wrap/_utility.scss
@@ -1,37 +1,39 @@
 @import "mixin";
 
 @if settings(utility-flex-wrap) {
-  /* ---
-  title: Flex Wrap Utility
-  section: Utilities
-  ---
-  <table>
-  <thead>
-  <tr>
-  <th>Class Name</th>
-  <th>Property</th>
-  </thead>
-  <tbody>
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    title: Flex Wrap Utility
+    section: Utilities
+    ---
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-  // NOTE: This @each loop is only for document generation
-  @each $value in $util-flex-wrap-values {
+    // NOTE: This @each loop is only for document generation
+    @each $value in $util-flex-wrap-values {
+      /* ---
+      section: Utilities
+      ---
+      <tr>
+      <td>`.#{settings(prefix)}-flex-#{$value}`</td>
+      <td>`flex-wrap: #{$value}`</td>
+      </tr>
+      */
+    }
+
     /* ---
     section: Utilities
     ---
-    <tr>
-    <td>`.#{settings(prefix)}-flex-#{$value}`</td>
-    <td>`flex-wrap: #{$value}`</td>
-    </tr>
+    </tbody>
+    </table>
     */
   }
-
-  /* ---
-  section: Utilities
-  ---
-  </tbody>
-  </table>
-  */
 
   // Load the mixin
   @include sparkle-flex-wrap;

--- a/utilities/justify-content/_test.scss
+++ b/utilities/justify-content/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -21,7 +23,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-justify-content();
+        @include sparkle-justify-content;
       }
       @include expect {
         .util-justify-content-center {

--- a/utilities/justify-content/_utility.scss
+++ b/utilities/justify-content/_utility.scss
@@ -1,37 +1,38 @@
 @import "mixin";
 
 @if settings(utility-justify-content) {
-  /* ---
-  title: Justify Content Utility
-  section: Utilities
-  ---
-  <table>
-  <thead>
-  <tr>
-  <th>Class Name</th>
-  <th>Property</th>
-  </thead>
-  <tbody>
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    title: Justify Content Utility
+    section: Utilities
+    ---
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
+    // NOTE: This @each loop is only for document generation
+    @each $value in $util-text-values {
+      /* ---
+      section: Utilities
+      ---
+      <tr>
+      <td>`.#{settings(prefix)}-justify-content-#{$value}`</td>
+      <td>`justify-content: #{$value}`</td>
+      </tr>
+      */
+    }
 
-  // NOTE: This @each loop is only for document generation
-  @each $value in $util-text-values {
     /* ---
     section: Utilities
     ---
-    <tr>
-    <td>`.#{settings(prefix)}-justify-content-#{$value}`</td>
-    <td>`justify-content: #{$value}`</td>
-    </tr>
+    </tbody>
+    </table>
     */
   }
-
-  /* ---
-  section: Utilities
-  ---
-  </tbody>
-  </table>
-  */
 
   // Load the mixin
   @include sparkle-justify-content;

--- a/utilities/order/_test.scss
+++ b/utilities/order/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -21,7 +23,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-order();
+        @include sparkle-order;
       }
       @include expect {
         .util-order-minus-1 {

--- a/utilities/order/_utility.scss
+++ b/utilities/order/_utility.scss
@@ -1,37 +1,39 @@
 @import "mixin";
 
 @if settings(utility-order) {
-  /* ---
-  title: Order Utility
-  section: Utilities
-  ---
-  <table>
-  <thead>
-  <tr>
-  <th>Class Name</th>
-  <th>Property</th>
-  </thead>
-  <tbody>
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    title: Order Utility
+    section: Utilities
+    ---
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-  // NOTE: This @each loop is only for document generation
-  @each $value in $util-order-values {
+    // NOTE: This @each loop is only for document generation
+    @each $value in $util-order-values {
+      /* ---
+      section: Utilities
+      ---
+      <tr>
+      <td>`.#{settings(prefix)}-order-#{$value}`</td>
+      <td>`order: #{$value}`</td>
+      </tr>
+      */
+    }
+
     /* ---
     section: Utilities
     ---
-    <tr>
-    <td>`.#{settings(prefix)}-order-#{$value}`</td>
-    <td>`order: #{$value}`</td>
-    </tr>
+    </tbody>
+    </table>
     */
   }
-
-  /* ---
-  section: Utilities
-  ---
-  </tbody>
-  </table>
-  */
 
   // Load the mixin
   @include sparkle-order;

--- a/utilities/position/_test.scss
+++ b/utilities/position/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -20,7 +22,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-position();
+        @include sparkle-position;
       }
       @include expect {
         .util-position-fixed {

--- a/utilities/position/_utility.scss
+++ b/utilities/position/_utility.scss
@@ -1,37 +1,39 @@
 @import "mixin";
 
 @if settings(utility-position) {
-  /* ---
-  title: Position Utility
-  section: Utilities
-  ---
-  <table>
-  <thead>
-  <tr>
-  <th>Class Name</th>
-  <th>Property</th>
-  </thead>
-  <tbody>
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    title: Position Utility
+    section: Utilities
+    ---
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-  // NOTE: This @each loop is only for document generation
-  @each $value in $util-position-values {
+    // NOTE: This @each loop is only for document generation
+    @each $value in $util-position-values {
+      /* ---
+      section: Utilities
+      ---
+      <tr>
+      <td>`.#{settings(prefix)}-position-#{$value}`</td>
+      <td>`position: #{$value}`</td>
+      </tr>
+      */
+    }
+
     /* ---
     section: Utilities
     ---
-    <tr>
-    <td>`.#{settings(prefix)}-position-#{$value}`</td>
-    <td>`position: #{$value}`</td>
-    </tr>
+    </tbody>
+    </table>
     */
   }
-
-  /* ---
-  section: Utilities
-  ---
-  </tbody>
-  </table>
-  */
 
   // Load the mixin
   @include sparkle-position;

--- a/utilities/text-align/_test.scss
+++ b/utilities/text-align/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -21,7 +23,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-text-align();
+        @include sparkle-text-align;
       }
       @include expect {
         .util-text-left {

--- a/utilities/text-align/_utility.scss
+++ b/utilities/text-align/_utility.scss
@@ -1,37 +1,39 @@
 @import "mixin";
 
 @if settings(utility-text-align) {
-  /* ---
-  title: Text-Align Utility
-  section: Utilities
-  ---
-  <table>
-  <thead>
-  <tr>
-  <th>Class Name</th>
-  <th>Property</th>
-  </thead>
-  <tbody>
-  */
+  @if $sparkle-show-docs {
+    /* ---
+    title: Text-Align Utility
+    section: Utilities
+    ---
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-  // NOTE: This @each loop is only for document generation
-  @each $value in $util-text-values {
+    // NOTE: This @each loop is only for document generation
+    @each $value in $util-text-values {
+      /* ---
+      section: Utilities
+      ---
+      <tr>
+      <td>`.#{settings(prefix)}-text-#{$value}`</td>
+      <td>`text-align: #{$value}`</td>
+      </tr>
+      */
+    }
+
     /* ---
     section: Utilities
     ---
-    <tr>
-    <td>`.#{settings(prefix)}-text-#{$value}`</td>
-    <td>`text-align: #{$value}`</td>
-    </tr>
+    </tbody>
+    </table>
     */
   }
-
-  /* ---
-  section: Utilities
-  ---
-  </tbody>
-  </table>
-  */
 
   // Load the mixin
   @include sparkle-text-align;

--- a/utilities/text-decoration/_test.scss
+++ b/utilities/text-decoration/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -21,7 +23,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-text-decoration();
+        @include sparkle-text-decoration;
       }
       @include expect {
         .util-text-decoration-none {

--- a/utilities/text-decoration/_utility.scss
+++ b/utilities/text-decoration/_utility.scss
@@ -1,40 +1,40 @@
 @import "mixin";
 
 @if settings(utility-text-decoration) {
-  /* ---
-title: Text Decoration Utility
-section: Utilities
----
-
-<table>
-<thead>
-<tr>
-<th>Class Name</th>
-<th>Property</th>
-</thead>
-<tbody>
-*/
-
-  // NOTE: This @each loop is only for document generation
-  @each $value in $util-text-decoration {
+  @if $sparkle-show-docs {
     /* ---
-section: Utilities
----
+    title: Text Decoration Utility
+    section: Utilities
+    ---
 
-<tr>
-<td>`.#{settings(prefix)}-text-decoration-#{$value}`</td>
-<td>`text-decoration: #{$value}`</td>
-</tr>
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-*/
+    // NOTE: This @each loop is only for document generation
+    @each $value in $util-text-decoration {
+      /* ---
+        section: Utilities
+        ---
+        <tr>
+        <td>`.#{settings(prefix)}-text-decoration-#{$value}`</td>
+        <td>`text-decoration: #{$value}`</td>
+        </tr>
+        */
+    }
+
+    /* ---
+      section: Utilities
+      ---
+      </tbody>
+      </table>
+      */
   }
-
-  /* ---
-section: Utilities
----
-</tbody>
-</table>
-*/
 
   // Load the mixin
   @include sparkle-text-decoration;

--- a/utilities/text-transform/_test.scss
+++ b/utilities/text-transform/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -21,7 +23,7 @@ $media-queries: (
   @include it('outputs the proper utility classes') {
     @include assert {
       @include output {
-        @include sparkle-text-transform();
+        @include sparkle-text-transform;
       }
       @include expect {
         .util-text-uppercase {

--- a/utilities/text-transform/_utility.scss
+++ b/utilities/text-transform/_utility.scss
@@ -1,40 +1,42 @@
 @import "mixin";
 
 @if settings(utility-text-transform) {
-  /* ---
-title: Text Transform Utility
-section: Utilities
----
-
-<table>
-<thead>
-<tr>
-<th>Class Name</th>
-<th>Property</th>
-</thead>
-<tbody>
-*/
-
-  // NOTE: This @each loop is only for document generation
-  @each $value in $util-text-transform {
+  @if $sparkle-show-docs {
     /* ---
-section: Utilities
----
+    title: Text Transform Utility
+    section: Utilities
+    ---
 
-<tr>
-<td>`.#{settings(prefix)}-text-#{$value}`</td>
-<td>`text-transform: #{$value}`</td>
-</tr>
+    <table>
+    <thead>
+    <tr>
+    <th>Class Name</th>
+    <th>Property</th>
+    </thead>
+    <tbody>
+    */
 
-*/
+    // NOTE: This @each loop is only for document generation
+    @each $value in $util-text-transform {
+      /* ---
+      section: Utilities
+      ---
+
+      <tr>
+      <td>`.#{settings(prefix)}-text-#{$value}`</td>
+      <td>`text-transform: #{$value}`</td>
+      </tr>
+
+      */
+    }
+
+    /* ---
+      section: Utilities
+      ---
+      </tbody>
+      </table>
+      */
   }
-
-  /* ---
-section: Utilities
----
-</tbody>
-</table>
-*/
 
   // Load the mixin
   @include sparkle-text-transform;

--- a/utilities/visually-hidden/_test.scss
+++ b/utilities/visually-hidden/_test.scss
@@ -1,4 +1,6 @@
 @import 'true';
+$sparkle-show-docs: false;
+
 @import 'mixin';
 @import '../../tools/settings/function';
 @import '../../tools/loop-mq/mixin';
@@ -16,7 +18,7 @@ $media-queries: (
   @include it('outputs the proper visually hidden classes') {
     @include assert {
       @include output {
-        @include sparkle-visually-hidden();
+        @include sparkle-visually-hidden;
       }
       @include expect {
         .util-visually-hidden {

--- a/utilities/visually-hidden/_utility.scss
+++ b/utilities/visually-hidden/_utility.scss
@@ -1,16 +1,18 @@
 @import 'mixin';
 
-/* ---
-title: Visually Hidden Utility
-section: Utilities
----
+@if $sparkle-show-docs {
+  /* ---
+  title: Visually Hidden Utility
+  section: Utilities
+  ---
 
-Use the `#{settings(prefix)}-visually-hidden` to hide content that should be hidden from the page visually, but still accessible to those using keyboard or screen reader controls.
+  Use the `#{settings(prefix)}-visually-hidden` to hide content that should be hidden from the page visually, but still accessible to those using keyboard or screen reader controls.
 
-```html
-<div class="#{settings(prefix)}-visually-hidden">...</div>
-```
-*/
+  ```html
+  <div class="#{settings(prefix)}-visually-hidden">...</div>
+  ```
+  */
+}
 
 @if settings('utility-visually-hidden') {
   @include sparkle-visually-hidden;


### PR DESCRIPTION
I was bothered by the CSS comments needed for docs generation being included in the CSS files using Sparkle, so this change makes the docs comments opt-in.

To test this out:
- [x] Run `npm install` to read the project
- [x] Run `npm test` to verify that tests still pass
- [x] Run `npm run stylelint` to verify the Sass is still well-formatted
- [x] Run `npm run docs` then open the generated CSS file `styleguide/docs.css`. This should still have all the CSS comments for docs.
- [x] Change the `$sparkle-show-docs` variable in `mdcss/docs.scss` from `true` to `false`. [See here](https://github.com/sparkbox/sparkle/compare/optional-docs?expand=1#diff-84f168bb2cc4553de552a8ec47ec0f724410f6208f59273a1333144ee7fc4573R1).
- [x] Run `npm run docs` then open the generated CSS file `styleguide/docs.css`. This should now no longer have the CSS comments for docs.
- [ ] Revert changes before merging!

