### PR TITLE
feat: State class loop mixin

### DIFF
--- a/_sparkle-settings.scss
+++ b/_sparkle-settings.scss
@@ -9,6 +9,7 @@ $settings: (
   'loop-mq': true,
   'print-classes': true,
   'system-color': true,
+  'system-color-states': true,
   'system-grid': true,
   'system-spacing': true,
   'system-font-family': true,

--- a/systems/color/_mixin.scss
+++ b/systems/color/_mixin.scss
@@ -1,0 +1,36 @@
+@mixin sparkle-loop-states {
+  @if settings(system-color-states) {
+    &,
+    &\:hover:hover,
+    &\:active:active,
+    &\:focus:focus {
+      @content;
+    }
+  }
+  @else {
+    @content;
+  }
+
+  @if settings(system-color-states) and settings(loop-mq) {
+    // This is a variation on the loop-mq mixin
+    @each $key, $val in $media-queries {
+      // Checks that the media query is a number
+      @if $val != $val + "" {
+        @media (min-width: #{$val}) {
+          &\@#{$key},
+          &\@#{$key}\:hover:hover,
+          &\@#{$key}\:active:active,
+          &\@#{$key}\:focus:focus {
+            @content;
+          }
+        }
+      }
+    }
+  }
+  @else if settings(loop-mq) {
+    @include loop-mq {
+      @content;
+    }
+  }
+}
+

--- a/systems/color/_test.scss
+++ b/systems/color/_test.scss
@@ -1,0 +1,50 @@
+@import 'true';
+$sparkle-show-docs: false;
+
+@import 'mixin';
+
+$settings: (
+  'loop-mq': true,
+  'system-color-states': true
+);
+
+$media-queries: (
+  'sm': 40rem,
+);
+
+$colors: (
+  'primary': deeppink,
+);
+
+
+
+@include describe('The color function and state mixin') {
+  @include it('outputs the media-query properties and state classes of the loop.') {
+    @include assert {
+      @include output {
+        .test {
+          @include sparkle-loop-states {
+            color: deeppink;
+          }
+        }
+      }
+      @include expect {
+        .test,
+        .test\:hover:hover,
+        .test\:active:active,
+        .test\:focus:focus {
+          color: deeppink;
+        }
+
+        @media (min-width: 40rem) {
+          .test\@sm,
+          .test\@sm\:hover:hover,
+          .test\@sm\:active:active,
+          .test\@sm\:focus:focus {
+            color: deeppink;
+          }
+        }
+      }
+    }
+  }
+}

--- a/systems/color/background/_utility.scss
+++ b/systems/color/background/_utility.scss
@@ -1,3 +1,5 @@
+@import '../mixin';
+
 @if settings('utility-background-color') {
   @if $sparkle-show-docs {
     /* ---
@@ -34,11 +36,8 @@
       */
     }
 
-    .#{settings(prefix)}-background-color-#{$key},
-    .#{settings(prefix)}-background-color-#{$key}\:hover:hover,
-    .#{settings(prefix)}-background-color-#{$key}\:active:active,
-    .#{settings(prefix)}-background-color-#{$key}\:focus:focus {
-      @include loop-mq {
+    .#{settings(prefix)}-background-color-#{$key} {
+      @include sparkle-loop-states {
         background-color: $val;
       }
     }

--- a/systems/color/border/_utility.scss
+++ b/systems/color/border/_utility.scss
@@ -1,3 +1,5 @@
+@import '../mixin';
+
 @if settings('utility-border-color') {
   @if $sparkle-show-docs {
     /* ---
@@ -32,11 +34,8 @@
       </tr>
       */
     }
-    .#{settings(prefix)}-border-color-#{$key},
-    .#{settings(prefix)}-border-color-#{$key}\:hover:hover,
-    .#{settings(prefix)}-border-color-#{$key}\:active:active,
-    .#{settings(prefix)}-border-color-#{$key}\:focus:focus {
-      @include loop-mq {
+    .#{settings(prefix)}-border-color-#{$key} {
+      @include sparkle-loop-states {
         border-color: $val;
       }
     }

--- a/systems/color/foreground/_utility.scss
+++ b/systems/color/foreground/_utility.scss
@@ -1,3 +1,5 @@
+@import '../mixin';
+
 @if settings('utility-foreground-color') {
   @if $sparkle-show-docs {
     /* ---
@@ -32,11 +34,8 @@
       </tr>
       */
     }
-    .#{settings(prefix)}-color-#{$key},
-    .#{settings(prefix)}-color-#{$key}\:hover:hover,
-    .#{settings(prefix)}-color-#{$key}\:active:active,
-    .#{settings(prefix)}-color-#{$key}\:focus:focus {
-      @include loop-mq {
+    .#{settings(prefix)}-color-#{$key} {
+      @include sparkle-loop-states {
         color: $val;
       }
     }

--- a/systems/color/outline/_utility.scss
+++ b/systems/color/outline/_utility.scss
@@ -1,3 +1,5 @@
+@import '../mixin';
+
 @if settings('utility-outline-color') {
   @if $sparkle-show-docs {
     /* ---
@@ -33,11 +35,8 @@
       */
     }
 
-    .#{settings(prefix)}-outline-#{$key},
-    .#{settings(prefix)}-outline-#{$key}\:hover:hover,
-    .#{settings(prefix)}-outline-#{$key}\:active:active,
-    .#{settings(prefix)}-outline-#{$key}\:focus:focus {
-      @include loop-mq {
+    .#{settings(prefix)}-outline-#{$key} {
+      @include sparkle-loop-states {
         outline-color: $val;
       }
     }

--- a/systems/color/text-decoration/_utility.scss
+++ b/systems/color/text-decoration/_utility.scss
@@ -1,3 +1,5 @@
+@import '../mixin';
+
 @if settings('utility-text-decoration-color') {
   @if $sparkle-show-docs {
     /* ---
@@ -34,11 +36,8 @@
       </tr>
       */
     }
-    .#{settings(prefix)}-decoration-color-#{$key},
-    .#{settings(prefix)}-decoration-color-#{$key}\:hover:hover,
-    .#{settings(prefix)}-decoration-color-#{$key}\:active:active,
-    .#{settings(prefix)}-decoration-color-#{$key}\:focus:focus {
-      @include loop-mq {
+    .#{settings(prefix)}-decoration-color-#{$key} {
+      @include sparkle-loop-states {
         text-decoration-color: $val;
       }
     }

--- a/test/test.scss
+++ b/test/test.scss
@@ -33,6 +33,7 @@
 @import "../systems/color/border/test";
 @import "../systems/color/outline/test";
 @import "../systems/color/text-decoration/test";
+@import "../systems/color/test";
 @import "../systems/z-index/test";
 @import "../systems/font/family/test";
 @import "../systems/font/size/test";


### PR DESCRIPTION
This addresses issue #68 by adding a new feature, the sparkle state loop mixin. This mixin is a private mixin for the color system to generate state-based class names and work with the media query class suffixes. A test has been added to verify the mixin output.

To verify this code:
1. [x] Pull down this branch
2. [x] If it has been a while, run `npm install`
3. [x] Run `npm start` to generate the CSS file
4. [x] Run `npm test` to verify tests pass
4. [x] Open the [W3C CSS Validator](https://jigsaw.w3.org/css-validator/validator)
5. [x] Upload the generated CSS file: `./sparkle/styleguide/docs.css`
6. [x] Verify that the CSS is valid

