### PR TITLE
fix: Correct mixin output of x and y axis properties

### DIFF
--- a/systems/spacing/_mixins.scss
+++ b/systems/spacing/_mixins.scss
@@ -13,11 +13,11 @@
       #{$type}: $space;
     }
   } @else if $side == 'x-axis' {
-    #{$prefix}top: $space;
-    #{$prefix}bottom: $space;
-  } @else if $side == 'y-axis' {
     #{$prefix}right: $space;
     #{$prefix}left: $space;
+  } @else if $side == 'y-axis' {
+    #{$prefix}top: $space;
+    #{$prefix}bottom: $space;
   } @else {
     #{$prefix}#{$side}: $space;
   }

--- a/systems/spacing/margin/_test.scss
+++ b/systems/spacing/margin/_test.scss
@@ -14,8 +14,8 @@ $settings: (
 $sides: (
   all: all,
   bottom: btm,
-  x-axis: vrt,
-  y-axis: hrz
+  x-axis: hrz,
+  y-axis: vrt
 );
 
 $spacer: (
@@ -51,16 +51,6 @@ $media-queries: (
           margin-bottom: 1rem;
         }
 
-        .true-test-margin-vrt-sm {
-          margin-top: 0.5rem;
-          margin-bottom: 0.5rem;
-        }
-
-        .true-test-margin-vrt-lg {
-          margin-top: 1rem;
-          margin-bottom: 1rem;
-        }
-
         .true-test-margin-hrz-sm {
           margin-right: 0.5rem;
           margin-left: 0.5rem;
@@ -69,6 +59,16 @@ $media-queries: (
         .true-test-margin-hrz-lg {
           margin-right: 1rem;
           margin-left: 1rem;
+        }
+
+        .true-test-margin-vrt-sm {
+          margin-top: 0.5rem;
+          margin-bottom: 0.5rem;
+        }
+
+        .true-test-margin-vrt-lg {
+          margin-top: 1rem;
+          margin-bottom: 1rem;
         }
 
         @media (min-width: 30rem) {
@@ -88,16 +88,6 @@ $media-queries: (
             margin-bottom: 1rem;
           }
 
-          .true-test-margin-vrt-sm\@sm {
-            margin-top: 0.5rem;
-            margin-bottom: 0.5rem;
-          }
-
-          .true-test-margin-vrt-lg\@sm {
-            margin-top: 1rem;
-            margin-bottom: 1rem;
-          }
-
           .true-test-margin-hrz-sm\@sm {
             margin-right: 0.5rem;
             margin-left: 0.5rem;
@@ -106,6 +96,16 @@ $media-queries: (
           .true-test-margin-hrz-lg\@sm {
             margin-right: 1rem;
             margin-left: 1rem;
+          }
+
+          .true-test-margin-vrt-sm\@sm {
+            margin-top: 0.5rem;
+            margin-bottom: 0.5rem;
+          }
+
+          .true-test-margin-vrt-lg\@sm {
+            margin-top: 1rem;
+            margin-bottom: 1rem;
           }
         }
 
@@ -126,16 +126,6 @@ $media-queries: (
             margin-bottom: 1rem;
           }
 
-          .true-test-margin-vrt-sm\@lg {
-            margin-top: 0.5rem;
-            margin-bottom: 0.5rem;
-          }
-
-          .true-test-margin-vrt-lg\@lg {
-            margin-top: 1rem;
-            margin-bottom: 1rem;
-          }
-
           .true-test-margin-hrz-sm\@lg {
             margin-right: 0.5rem;
             margin-left: 0.5rem;
@@ -144,6 +134,16 @@ $media-queries: (
           .true-test-margin-hrz-lg\@lg {
             margin-right: 1rem;
             margin-left: 1rem;
+          }
+
+          .true-test-margin-vrt-sm\@lg {
+            margin-top: 0.5rem;
+            margin-bottom: 0.5rem;
+          }
+
+          .true-test-margin-vrt-lg\@lg {
+            margin-top: 1rem;
+            margin-bottom: 1rem;
           }
         }
 
@@ -164,16 +164,6 @@ $media-queries: (
             margin-bottom: 1rem;
           }
 
-          .true-test-margin-vrt-sm\@print {
-            margin-top: 0.5rem;
-            margin-bottom: 0.5rem;
-          }
-
-          .true-test-margin-vrt-lg\@print {
-            margin-top: 1rem;
-            margin-bottom: 1rem;
-          }
-
           .true-test-margin-hrz-sm\@print {
             margin-right: 0.5rem;
             margin-left: 0.5rem;
@@ -182,6 +172,16 @@ $media-queries: (
           .true-test-margin-hrz-lg\@print {
             margin-right: 1rem;
             margin-left: 1rem;
+          }
+
+          .true-test-margin-vrt-sm\@print {
+            margin-top: 0.5rem;
+            margin-bottom: 0.5rem;
+          }
+
+          .true-test-margin-vrt-lg\@print {
+            margin-top: 1rem;
+            margin-bottom: 1rem;
           }
         }
       }

--- a/systems/spacing/padding/_test.scss
+++ b/systems/spacing/padding/_test.scss
@@ -14,8 +14,8 @@ $settings: (
 $sides: (
   all: all,
   bottom: btm,
-  x-axis: vrt,
-  y-axis: hrz
+  x-axis: hrz,
+  y-axis: vrt
 );
 
 $spacer: (
@@ -51,16 +51,6 @@ $media-queries: (
           padding-bottom: 1rem;
         }
 
-        .true-test-pad-vrt-sm {
-          padding-top: 0.5rem;
-          padding-bottom: 0.5rem;
-        }
-
-        .true-test-pad-vrt-lg {
-          padding-top: 1rem;
-          padding-bottom: 1rem;
-        }
-
         .true-test-pad-hrz-sm {
           padding-right: 0.5rem;
           padding-left: 0.5rem;
@@ -69,6 +59,16 @@ $media-queries: (
         .true-test-pad-hrz-lg {
           padding-right: 1rem;
           padding-left: 1rem;
+        }
+
+        .true-test-pad-vrt-sm {
+          padding-top: 0.5rem;
+          padding-bottom: 0.5rem;
+        }
+
+        .true-test-pad-vrt-lg {
+          padding-top: 1rem;
+          padding-bottom: 1rem;
         }
 
         @media (min-width: 30rem) {
@@ -88,16 +88,6 @@ $media-queries: (
             padding-bottom: 1rem;
           }
 
-          .true-test-pad-vrt-sm\@sm {
-            padding-top: 0.5rem;
-            padding-bottom: 0.5rem;
-          }
-
-          .true-test-pad-vrt-lg\@sm {
-            padding-top: 1rem;
-            padding-bottom: 1rem;
-          }
-
           .true-test-pad-hrz-sm\@sm {
             padding-right: 0.5rem;
             padding-left: 0.5rem;
@@ -106,6 +96,16 @@ $media-queries: (
           .true-test-pad-hrz-lg\@sm {
             padding-right: 1rem;
             padding-left: 1rem;
+          }
+
+          .true-test-pad-vrt-sm\@sm {
+            padding-top: 0.5rem;
+            padding-bottom: 0.5rem;
+          }
+
+          .true-test-pad-vrt-lg\@sm {
+            padding-top: 1rem;
+            padding-bottom: 1rem;
           }
         }
 
@@ -126,16 +126,6 @@ $media-queries: (
             padding-bottom: 1rem;
           }
 
-          .true-test-pad-vrt-sm\@lg {
-            padding-top: 0.5rem;
-            padding-bottom: 0.5rem;
-          }
-
-          .true-test-pad-vrt-lg\@lg {
-            padding-top: 1rem;
-            padding-bottom: 1rem;
-          }
-
           .true-test-pad-hrz-sm\@lg {
             padding-right: 0.5rem;
             padding-left: 0.5rem;
@@ -144,6 +134,16 @@ $media-queries: (
           .true-test-pad-hrz-lg\@lg {
             padding-right: 1rem;
             padding-left: 1rem;
+          }
+
+          .true-test-pad-vrt-sm\@lg {
+            padding-top: 0.5rem;
+            padding-bottom: 0.5rem;
+          }
+
+          .true-test-pad-vrt-lg\@lg {
+            padding-top: 1rem;
+            padding-bottom: 1rem;
           }
         }
 
@@ -164,16 +164,6 @@ $media-queries: (
             padding-bottom: 1rem;
           }
 
-          .true-test-pad-vrt-sm\@print {
-            padding-top: 0.5rem;
-            padding-bottom: 0.5rem;
-          }
-
-          .true-test-pad-vrt-lg\@print {
-            padding-top: 1rem;
-            padding-bottom: 1rem;
-          }
-
           .true-test-pad-hrz-sm\@print {
             padding-right: 0.5rem;
             padding-left: 0.5rem;
@@ -182,6 +172,16 @@ $media-queries: (
           .true-test-pad-hrz-lg\@print {
             padding-right: 1rem;
             padding-left: 1rem;
+          }
+
+          .true-test-pad-vrt-sm\@print {
+            padding-top: 0.5rem;
+            padding-bottom: 0.5rem;
+          }
+
+          .true-test-pad-vrt-lg\@print {
+            padding-top: 1rem;
+            padding-bottom: 1rem;
           }
         }
       }

--- a/systems/spacing/position/_test.scss
+++ b/systems/spacing/position/_test.scss
@@ -14,8 +14,8 @@ $settings: (
 $sides: (
   all: all,
   bottom: btm,
-  x-axis: vrt,
-  y-axis: hrz
+  x-axis: hrz,
+  y-axis: vrt
 );
 
 $spacer: (
@@ -57,16 +57,6 @@ $media-queries: (
           bottom: 1rem;
         }
 
-        .true-test-position-vrt-sm {
-          top: 0.5rem;
-          bottom: 0.5rem;
-        }
-
-        .true-test-position-vrt-lg {
-          top: 1rem;
-          bottom: 1rem;
-        }
-
         .true-test-position-hrz-sm {
           right: 0.5rem;
           left: 0.5rem;
@@ -75,6 +65,16 @@ $media-queries: (
         .true-test-position-hrz-lg {
           right: 1rem;
           left: 1rem;
+        }
+
+        .true-test-position-vrt-sm {
+          top: 0.5rem;
+          bottom: 0.5rem;
+        }
+
+        .true-test-position-vrt-lg {
+          top: 1rem;
+          bottom: 1rem;
         }
 
         @media (min-width: 30rem) {
@@ -100,16 +100,6 @@ $media-queries: (
             bottom: 1rem;
           }
 
-          .true-test-position-vrt-sm\@sm {
-            top: 0.5rem;
-            bottom: 0.5rem;
-          }
-
-          .true-test-position-vrt-lg\@sm {
-            top: 1rem;
-            bottom: 1rem;
-          }
-
           .true-test-position-hrz-sm\@sm {
             right: 0.5rem;
             left: 0.5rem;
@@ -118,6 +108,16 @@ $media-queries: (
           .true-test-position-hrz-lg\@sm {
             right: 1rem;
             left: 1rem;
+          }
+
+          .true-test-position-vrt-sm\@sm {
+            top: 0.5rem;
+            bottom: 0.5rem;
+          }
+
+          .true-test-position-vrt-lg\@sm {
+            top: 1rem;
+            bottom: 1rem;
           }
         }
 
@@ -144,16 +144,6 @@ $media-queries: (
             bottom: 1rem;
           }
 
-          .true-test-position-vrt-sm\@lg {
-            top: 0.5rem;
-            bottom: 0.5rem;
-          }
-
-          .true-test-position-vrt-lg\@lg {
-            top: 1rem;
-            bottom: 1rem;
-          }
-
           .true-test-position-hrz-sm\@lg {
             right: 0.5rem;
             left: 0.5rem;
@@ -162,6 +152,16 @@ $media-queries: (
           .true-test-position-hrz-lg\@lg {
             right: 1rem;
             left: 1rem;
+          }
+
+          .true-test-position-vrt-sm\@lg {
+            top: 0.5rem;
+            bottom: 0.5rem;
+          }
+
+          .true-test-position-vrt-lg\@lg {
+            top: 1rem;
+            bottom: 1rem;
           }
         }
 
@@ -188,16 +188,6 @@ $media-queries: (
             bottom: 1rem;
           }
 
-          .true-test-position-vrt-sm\@print {
-            top: 0.5rem;
-            bottom: 0.5rem;
-          }
-
-          .true-test-position-vrt-lg\@print {
-            top: 1rem;
-            bottom: 1rem;
-          }
-
           .true-test-position-hrz-sm\@print {
             right: 0.5rem;
             left: 0.5rem;
@@ -206,6 +196,16 @@ $media-queries: (
           .true-test-position-hrz-lg\@print {
             right: 1rem;
             left: 1rem;
+          }
+
+          .true-test-position-vrt-sm\@print {
+            top: 0.5rem;
+            bottom: 0.5rem;
+          }
+
+          .true-test-position-vrt-lg\@print {
+            top: 1rem;
+            bottom: 1rem;
           }
         }
       }


### PR DESCRIPTION
This corrects an error in the mixin that had swapped the x-axis and y-axis output for the spacing system utility classes, as recorded in #66.

To verify this code:

- [ ] Pull down this branch
- [ ] If it has been a while, run `npm install`
- [ ] Run `npm test` to verify tests pass
- [ ] Run `npm run stylelint` to ensure the Sass passes linting
- [ ] Run `npm start` then open `styleguide/index.html` in a browser and verify the Spacing System utility classes