### PR TITLE
chore: add workflow to deploy docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install Dependencies
+        run: npm cit
+
+      - name: Build Docs
+        run: npm run docs
+
+      - name: Deploy Docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./styleguide


### PR DESCRIPTION
Howdy pardners and happy Hacktoberfest! 🎃 🤠 . It's your friendly neighborhood cowboy coder here with an unsolicited PR. I was looking through the sparkle repo and thought it would be helpful to see the styleguide without cloning the repo locally. I also noticed that https://sparkbox.github.io/sparkle/ currently appears to have a one-off deployment that just shows the sparkle logo. 

This PR adds a Github workflow to deploy the updated styleguide to `gh-pages` whenever changes are merged into `main`. 

In order to test this, I forked the repo.
- You can see the [result of the workflow run here](https://github.com/jonoliver/sparkle/runs/3866171993?check_suite_focus=true)
- You can see the [deployed styleguide here](http://jonoliver.codes/sparkle/)

Feel free to close this PR if y'all have other plans for https://sparkbox.github.io/sparkle/. Also happy to address any concerns. Thanks for looking!
