### PR TITLE
chore: default codeowners setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo.
+*  @zastrow @kaseybon @catheraaine


### PR DESCRIPTION
This PR sets up the default `CODEOWNERS` for the repo @catheraaine, @zastrow, and @kaseybon.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners