### PR TITLE
Docs update

### DIFF
--- a/systems/color/background/_utility.scss
+++ b/systems/color/background/_utility.scss
@@ -11,7 +11,7 @@
     <thead>
     <tr>
     <th></th>
-    <th>Default Class</th>
+    <th>Default Class Name</th></th>
     <th>`:hover` Class</th>
     <th>`:focus` Class</th>
     <th>`:active` Class</th>

--- a/systems/color/background/_utility.scss
+++ b/systems/color/background/_utility.scss
@@ -11,7 +11,7 @@
     <thead>
     <tr>
     <th></th>
-    <th>Default Class Name</th></th>
+    <th>Default Class Name</th>
     <th>`:hover` Class</th>
     <th>`:focus` Class</th>
     <th>`:active` Class</th>

--- a/systems/color/background/_utility.scss
+++ b/systems/color/background/_utility.scss
@@ -28,10 +28,10 @@
       ---
       <tr>
       <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-      <td>`.#{settings(prefix)}-background-color-#{$key}`</td>
-      <td>`.#{settings(prefix)}-background-color-#{$key}:hover`</td>
-      <td>`.#{settings(prefix)}-background-color-#{$key}:focus`</td>
-      <td>`.#{settings(prefix)}-background-color-#{$key}:active`</td>
+      <td>`#{settings(prefix)}-background-color-#{$key}`</td>
+      <td>`#{settings(prefix)}-background-color-#{$key}:hover`</td>
+      <td>`#{settings(prefix)}-background-color-#{$key}:focus`</td>
+      <td>`#{settings(prefix)}-background-color-#{$key}:active`</td>
       </tr>
       */
     }

--- a/systems/color/border/_utility.scss
+++ b/systems/color/border/_utility.scss
@@ -10,7 +10,7 @@
     <thead>
     <tr>
     <th></th>
-    <th>Default Class</th>
+    <th>Default Class Name</th></th>
     <th>`:hover` Class</th>
     <th>`:focus` Class</th>
     <th>`:active` Class</th>

--- a/systems/color/border/_utility.scss
+++ b/systems/color/border/_utility.scss
@@ -27,10 +27,10 @@
       ---
       <tr>
       <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-      <td>`.#{settings(prefix)}-border-color-#{$key}`</td>
-      <td>`.#{settings(prefix)}-border-color-#{$key}:hover`</td>
-      <td>`.#{settings(prefix)}-border-color-#{$key}:focus`</td>
-      <td>`.#{settings(prefix)}-border-color-#{$key}:active`</td>
+      <td>`#{settings(prefix)}-border-color-#{$key}`</td>
+      <td>`#{settings(prefix)}-border-color-#{$key}:hover`</td>
+      <td>`#{settings(prefix)}-border-color-#{$key}:focus`</td>
+      <td>`#{settings(prefix)}-border-color-#{$key}:active`</td>
       </tr>
       */
     }

--- a/systems/color/border/_utility.scss
+++ b/systems/color/border/_utility.scss
@@ -10,7 +10,7 @@
     <thead>
     <tr>
     <th></th>
-    <th>Default Class Name</th></th>
+    <th>Default Class Name</th>
     <th>`:hover` Class</th>
     <th>`:focus` Class</th>
     <th>`:active` Class</th>

--- a/systems/color/foreground/_utility.scss
+++ b/systems/color/foreground/_utility.scss
@@ -10,7 +10,7 @@
     <thead>
     <tr>
     <th></th>
-    <th>Default Class</th>
+    <th>Default Class Name</th></th>
     <th>`:hover` Class</th>
     <th>`:focus` Class</th>
     <th>`:active` Class</th>

--- a/systems/color/foreground/_utility.scss
+++ b/systems/color/foreground/_utility.scss
@@ -10,7 +10,7 @@
     <thead>
     <tr>
     <th></th>
-    <th>Default Class Name</th></th>
+    <th>Default Class Name</th>
     <th>`:hover` Class</th>
     <th>`:focus` Class</th>
     <th>`:active` Class</th>

--- a/systems/color/foreground/_utility.scss
+++ b/systems/color/foreground/_utility.scss
@@ -27,10 +27,10 @@
       ---
       <tr>
       <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-      <td>`.#{settings(prefix)}-color-#{$key}`</td>
-      <td>`.#{settings(prefix)}-color-#{$key}:hover`</td>
-      <td>`.#{settings(prefix)}-color-#{$key}:focus`</td>
-      <td>`.#{settings(prefix)}-color-#{$key}:active`</td>
+      <td>`#{settings(prefix)}-color-#{$key}`</td>
+      <td>`#{settings(prefix)}-color-#{$key}:hover`</td>
+      <td>`#{settings(prefix)}-color-#{$key}:focus`</td>
+      <td>`#{settings(prefix)}-color-#{$key}:active`</td>
       </tr>
       */
     }

--- a/systems/color/outline/_utility.scss
+++ b/systems/color/outline/_utility.scss
@@ -10,7 +10,7 @@
     <thead>
     <tr>
     <th></th>
-    <th>Default Class</th>
+    <th>Default Class Name</th></th>
     <th>`:hover` Class</th>
     <th>`:focus` Class</th>
     <th>`:active` Class</th>

--- a/systems/color/outline/_utility.scss
+++ b/systems/color/outline/_utility.scss
@@ -27,10 +27,10 @@
       ---
       <tr>
       <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-      <td>`.#{settings(prefix)}-outline-#{$key}`</td>
-      <td>`.#{settings(prefix)}-outline-#{$key}:hover`</td>
-      <td>`.#{settings(prefix)}-outline-#{$key}:focus`</td>
-      <td>`.#{settings(prefix)}-outline-#{$key}:active`</td>
+      <td>`#{settings(prefix)}-outline-#{$key}`</td>
+      <td>`#{settings(prefix)}-outline-#{$key}:hover`</td>
+      <td>`#{settings(prefix)}-outline-#{$key}:focus`</td>
+      <td>`#{settings(prefix)}-outline-#{$key}:active`</td>
       </tr>
       */
     }

--- a/systems/color/outline/_utility.scss
+++ b/systems/color/outline/_utility.scss
@@ -10,7 +10,7 @@
     <thead>
     <tr>
     <th></th>
-    <th>Default Class Name</th></th>
+    <th>Default Class Name</th>
     <th>`:hover` Class</th>
     <th>`:focus` Class</th>
     <th>`:active` Class</th>

--- a/systems/color/text-decoration/_utility.scss
+++ b/systems/color/text-decoration/_utility.scss
@@ -12,7 +12,7 @@
     <thead>
     <tr>
     <th></th>
-    <th>Default Class</th>
+    <th>Default Class Name</th></th>
     <th>`:hover` Class</th>
     <th>`:focus` Class</th>
     <th>`:active` Class</th>

--- a/systems/color/text-decoration/_utility.scss
+++ b/systems/color/text-decoration/_utility.scss
@@ -29,10 +29,10 @@
       ---
       <tr>
       <td><svg height="18" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 0,18, 18,18 18,0z" fill="#{$val}" /></svg></td>
-      <td>`.#{settings(prefix)}-decoration-color-#{$key}`</td>
-      <td>`.#{settings(prefix)}-decoration-color-#{$key}:hover`</td>
-      <td>`.#{settings(prefix)}-decoration-color-#{$key}:focus`</td>
-      <td>`.#{settings(prefix)}-decoration-color-#{$key}:active`</td>
+      <td>`#{settings(prefix)}-decoration-color-#{$key}`</td>
+      <td>`#{settings(prefix)}-decoration-color-#{$key}:hover`</td>
+      <td>`#{settings(prefix)}-decoration-color-#{$key}:focus`</td>
+      <td>`#{settings(prefix)}-decoration-color-#{$key}:active`</td>
       </tr>
       */
     }

--- a/systems/color/text-decoration/_utility.scss
+++ b/systems/color/text-decoration/_utility.scss
@@ -12,7 +12,7 @@
     <thead>
     <tr>
     <th></th>
-    <th>Default Class Name</th></th>
+    <th>Default Class Name</th>
     <th>`:hover` Class</th>
     <th>`:focus` Class</th>
     <th>`:active` Class</th>

--- a/systems/font/family/_mixin.scss
+++ b/systems/font/family/_mixin.scss
@@ -7,7 +7,7 @@
 
     <table>
     <thead>
-    <th>Class</th>
+    <th>Class Name</th>
     <th>Function</th>
     <th>Name</th>
     </thead>

--- a/systems/font/size/_mixin.scss
+++ b/systems/font/size/_mixin.scss
@@ -7,7 +7,7 @@
 
     <table>
     <thead>
-    <th>Class</th>
+    <th>Class Name</th>
     <th>Function</th>
     <th>Size</th>
     </thead>

--- a/systems/font/weight/_mixin.scss
+++ b/systems/font/weight/_mixin.scss
@@ -7,7 +7,7 @@
 
     <table>
     <thead>
-    <th>Class</th>
+    <th>Class Name</th>
     <th>Function</th>
     <th>Weight</th>
     </thead>

--- a/systems/z-index/_utility.scss
+++ b/systems/z-index/_utility.scss
@@ -8,7 +8,7 @@
     <thead>
     <tr>
     <th>Property Value</th>
-    <th>Class</th>
+    <th>Class Name</th>
     <th>Function</th>
     </tr>
     </thead>

--- a/systems/z-index/_utility.scss
+++ b/systems/z-index/_utility.scss
@@ -23,7 +23,7 @@
       ---
       <tr>
         <td>#{$value}</td>
-        <td>`.#{settings(prefix)}-z-index-#{$key}`</td>
+        <td>`#{settings(prefix)}-z-index-#{$key}`</td>
         <td>`z-index(#{$key})`</td>
       </tr>
       */

--- a/utilities/align-items/_utility.scss
+++ b/utilities/align-items/_utility.scss
@@ -21,7 +21,7 @@
       section: Utilities
       ---
       <tr>
-      <td>`.#{settings(prefix)}-align-items-#{$value}`</td>
+      <td>`#{settings(prefix)}-align-items-#{$value}`</td>
       <td>`align-items: #{$value}`</td>
       </tr>
       */

--- a/utilities/align-self/_utility.scss
+++ b/utilities/align-self/_utility.scss
@@ -21,7 +21,7 @@
       section: Utilities
       ---
       <tr>
-      <td>`.#{settings(prefix)}-align-self-#{$value}`</td>
+      <td>`#{settings(prefix)}-align-self-#{$value}`</td>
       <td>`align-self: #{$value}`</td>
       </tr>
       */

--- a/utilities/display/_utility.scss
+++ b/utilities/display/_utility.scss
@@ -23,7 +23,7 @@
       ---
 
       <tr>
-      <td>`.#{settings(prefix)}-display-#{$value}`</td>
+      <td>`#{settings(prefix)}-display-#{$value}`</td>
       <td>`display: #{$value}`</td>
       </tr>
       */

--- a/utilities/flex-direction/_utility.scss
+++ b/utilities/flex-direction/_utility.scss
@@ -21,7 +21,7 @@
       section: Utilities
       ---
       <tr>
-      <td>`.#{settings(prefix)}-flex-#{$value}`</td>
+      <td>`#{settings(prefix)}-flex-#{$value}`</td>
       <td>`flex-direction: #{$value}`</td>
       </tr>
       */

--- a/utilities/flex-grow/_utility.scss
+++ b/utilities/flex-grow/_utility.scss
@@ -21,7 +21,7 @@
       section: Utilities
       ---
       <tr>
-      <td>`.#{settings(prefix)}-flex-grow-#{$value}`</td>
+      <td>`#{settings(prefix)}-flex-grow-#{$value}`</td>
       <td>`flex-grow: #{$value}`</td>
       </tr>
       */

--- a/utilities/flex-shrink/_utility.scss
+++ b/utilities/flex-shrink/_utility.scss
@@ -21,7 +21,7 @@
       section: Utilities
       ---
       <tr>
-      <td>`.#{settings(prefix)}-flex-shrink-#{$value}`</td>
+      <td>`#{settings(prefix)}-flex-shrink-#{$value}`</td>
       <td>`flex-shrink: #{$value}`</td>
       </tr>
       */

--- a/utilities/flex-wrap/_utility.scss
+++ b/utilities/flex-wrap/_utility.scss
@@ -21,7 +21,7 @@
       section: Utilities
       ---
       <tr>
-      <td>`.#{settings(prefix)}-flex-#{$value}`</td>
+      <td>`#{settings(prefix)}-flex-#{$value}`</td>
       <td>`flex-wrap: #{$value}`</td>
       </tr>
       */

--- a/utilities/justify-content/_utility.scss
+++ b/utilities/justify-content/_utility.scss
@@ -20,7 +20,7 @@
       section: Utilities
       ---
       <tr>
-      <td>`.#{settings(prefix)}-justify-content-#{$value}`</td>
+      <td>`#{settings(prefix)}-justify-content-#{$value}`</td>
       <td>`justify-content: #{$value}`</td>
       </tr>
       */

--- a/utilities/order/_utility.scss
+++ b/utilities/order/_utility.scss
@@ -21,7 +21,7 @@
       section: Utilities
       ---
       <tr>
-      <td>`.#{settings(prefix)}-order-#{$value}`</td>
+      <td>`#{settings(prefix)}-order-#{$value}`</td>
       <td>`order: #{$value}`</td>
       </tr>
       */

--- a/utilities/position/_utility.scss
+++ b/utilities/position/_utility.scss
@@ -21,7 +21,7 @@
       section: Utilities
       ---
       <tr>
-      <td>`.#{settings(prefix)}-position-#{$value}`</td>
+      <td>`#{settings(prefix)}-position-#{$value}`</td>
       <td>`position: #{$value}`</td>
       </tr>
       */

--- a/utilities/text-align/_utility.scss
+++ b/utilities/text-align/_utility.scss
@@ -21,7 +21,7 @@
       section: Utilities
       ---
       <tr>
-      <td>`.#{settings(prefix)}-text-#{$value}`</td>
+      <td>`#{settings(prefix)}-text-#{$value}`</td>
       <td>`text-align: #{$value}`</td>
       </tr>
       */

--- a/utilities/text-decoration/_utility.scss
+++ b/utilities/text-decoration/_utility.scss
@@ -22,7 +22,7 @@
         section: Utilities
         ---
         <tr>
-        <td>`.#{settings(prefix)}-text-decoration-#{$value}`</td>
+        <td>`#{settings(prefix)}-text-decoration-#{$value}`</td>
         <td>`text-decoration: #{$value}`</td>
         </tr>
         */

--- a/utilities/text-transform/_utility.scss
+++ b/utilities/text-transform/_utility.scss
@@ -23,7 +23,7 @@
       ---
 
       <tr>
-      <td>`.#{settings(prefix)}-text-#{$value}`</td>
+      <td>`#{settings(prefix)}-text-#{$value}`</td>
       <td>`text-transform: #{$value}`</td>
       </tr>
 


### PR DESCRIPTION
Update class headings and examples in tables to be more consistent.

To vaidate:
1. `npm run docs`
2. `cd styleguide`
3. `python -m SimpleHTTPServer 3000`
4. Verify that table headings are now consistently `Class Name`
5. Verify that the examples classes are not prefixed with `.`

Closes #46