### PR TITLE
feat: enable `auto` as value for spacing by default

### DIFF
--- a/globals/spacing/_map.scss
+++ b/globals/spacing/_map.scss
@@ -1,5 +1,6 @@
 $spacer: (
   'sm': 0.5rem,
   'md': 1rem,
-  'lg': 1.5rem
+  'lg': 1.5rem,
+  'auto': auto
 ) !default;

--- a/globals/spacing/_test.scss
+++ b/globals/spacing/_test.scss
@@ -4,7 +4,8 @@
 $spacer: (
   'sm': 0.5rem,
   'md': 1rem,
-  'lg': 1.5rem
+  'lg': 1.5rem,
+  'auto': auto
 );
 
 @include describe('The spacing global') {
@@ -38,6 +39,17 @@ $spacer: (
       $test,
       $expect,
       "Expected space global to output correct rem value for large."
+    );
+  }
+
+  @include it('outputs the correct value for auto') {
+    $test: space('auto');
+    $expect: auto;
+
+    @include assert-equal(
+      $test,
+      $expect,
+      "Expected space global to output correct value for large."
     );
   }
 }


### PR DESCRIPTION
Include `auto` as a default value for the `spacer` map, so auto utility classes for margins are available by default.

Closes #61
